### PR TITLE
feat: Fetch all stocks from the DB and make these options for single stock view

### DIFF
--- a/src/order_book_simulator/database/queries.py
+++ b/src/order_book_simulator/database/queries.py
@@ -68,3 +68,18 @@ async def get_stock_id_ticker_mapping(
     query = select(Stock.id, Stock.ticker).where(Stock.id.in_(stock_ids))
     result = await db.execute(query)
     return {str(row[0]): row[1] for row in result}
+
+
+async def get_all_stocks(db: AsyncSession) -> list[dict[str, str]]:
+    """
+    Gets all stocks from the database.
+
+    Args:
+        db: The database session.
+
+    Returns:
+        A list of dictionaries containing stock information.
+    """
+    query = select(Stock.ticker, Stock.company_name).order_by(Stock.ticker)
+    result = await db.execute(query)
+    return [{"ticker": row[0], "company_name": row[1]} for row in result]

--- a/src/order_book_simulator/gateway/routers/market_data_router.py
+++ b/src/order_book_simulator/gateway/routers/market_data_router.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from order_book_simulator.common.cache import order_book_cache
 from order_book_simulator.database.connection import get_db
 from order_book_simulator.database.queries import (
+    get_all_stocks,
     get_stock_by_ticker,
     get_stock_id_ticker_mapping,
 )
@@ -43,6 +44,24 @@ async def get_active_stocks(db: AsyncSession = Depends(get_db)) -> dict[str, Any
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "tickers": sorted(tickers),
         "stock_id_to_ticker": stock_id_to_ticker,
+    }
+
+
+@market_data_router.get("/stocks")
+async def get_all_stocks_endpoint(db: AsyncSession = Depends(get_db)) -> dict[str, Any]:
+    """
+    Returns all stocks available in the database.
+
+    Args:
+        db: The database session.
+
+    Returns:
+        A dictionary containing all stocks with their tickers and company names.
+    """
+    stocks = await get_all_stocks(db)
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "stocks": stocks,
     }
 
 

--- a/src/order_book_simulator/ui/components/api_client.py
+++ b/src/order_book_simulator/ui/components/api_client.py
@@ -85,3 +85,22 @@ def get_active_stock_tickers() -> dict | None:
     except Exception as e:
         st.error(f"Error fetching stock tickers: {e}")
         return None
+
+
+def get_all_stocks() -> dict | None:
+    """
+    Fetches all stocks from the database.
+
+    Returns:
+        Dictionary containing all stocks or None if unavailable
+    """
+    try:
+        response = requests.get(f"{GATEWAY_URL}/v1/market-data/stocks", timeout=5)
+        if response.status_code == 200:
+            return response.json()
+        else:
+            st.error(f"Failed to fetch stocks: {response.status_code}")
+            return None
+    except Exception as e:
+        st.error(f"Error fetching stocks: {e}")
+        return None

--- a/src/order_book_simulator/ui/streamlit_app.py
+++ b/src/order_book_simulator/ui/streamlit_app.py
@@ -59,10 +59,7 @@ def main():
         stocks_data = get_all_stocks()
         if stocks_data and stocks_data.get("stocks"):
             stock_options = [stock["ticker"] for stock in stocks_data["stocks"]]
-            if stock_options:
-                ticker = st.sidebar.selectbox("Select Stock", stock_options)
-            else:
-                st.sidebar.warning("No stocks available")
+            ticker = st.sidebar.selectbox("Select Stock", stock_options)
         # Fallback to hardcoded list if API is unavailable
         else:
             ticker = st.sidebar.selectbox(

--- a/src/order_book_simulator/ui/streamlit_app.py
+++ b/src/order_book_simulator/ui/streamlit_app.py
@@ -2,7 +2,10 @@ from datetime import datetime, timezone
 
 import streamlit as st
 
-from order_book_simulator.ui.components.api_client import check_gateway_connection
+from order_book_simulator.ui.components.api_client import (
+    check_gateway_connection,
+    get_all_stocks,
+)
 from order_book_simulator.ui.components.market_overview import (
     create_auto_refresh_market_overview,
     create_market_overview,
@@ -52,18 +55,20 @@ def main():
     # Stock selection (only shown for single stock view)
     ticker = None
     if view_mode == "Single Stock":
-        ticker = st.sidebar.selectbox(
-            "Select Stock",
-            [
-                "AAPL",
-                "AMZN",
-                "GOOGL",
-                "META",
-                "MSFT",
-                "NVDA",
-                "TSLA",
-            ],
-        )
+        # Fetch all stocks from database
+        stocks_data = get_all_stocks()
+        if stocks_data and stocks_data.get("stocks"):
+            stock_options = [stock["ticker"] for stock in stocks_data["stocks"]]
+            if stock_options:
+                ticker = st.sidebar.selectbox("Select Stock", stock_options)
+            else:
+                st.sidebar.warning("No stocks available")
+        # Fallback to hardcoded list if API is unavailable
+        else:
+            ticker = st.sidebar.selectbox(
+                "Select Stock",
+                ["AAPL", "AMZN", "GOOGL", "META", "MSFT", "NVDA", "TSLA"],
+            )
 
     # Auto-refresh controls
     st.sidebar.subheader("Auto-Refresh")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,22 @@ def db_session() -> AsyncSession:
         result = MagicMock()
         query_str = str(query)
 
+        # Handle get_all_stocks query first (returns ticker, company_name
+        # pairs)
+        if (
+            "company_name" in query_str.lower()
+            and "ticker" in query_str.lower()
+            and "WHERE" not in query_str.upper()
+        ):
+            mock_rows = [
+                ("AAPL", "Apple Inc."),
+                ("GOOGL", "Alphabet Inc."),
+                ("MSFT", "Microsoft Corporation"),
+                ("TSLA", "Tesla Inc."),
+            ]
+            result.__iter__.return_value = iter(mock_rows)
+            return result
+
         # Handle get_tickers_by_ids query
         if "SELECT stock.ticker" in query_str and hasattr(query, "compile"):
             compiled = query.compile()

--- a/tests/test_gateway/test_market_data_router.py
+++ b/tests/test_gateway/test_market_data_router.py
@@ -57,3 +57,33 @@ def test_get_active_stocks_empty(test_client):
     assert "stock_id_to_ticker" in data
     assert len(data["tickers"]) == 0
     assert len(data["stock_id_to_ticker"]) == 0
+
+
+def test_get_all_stocks(test_client):
+    """Tests getting all stocks from the database."""
+    response = test_client.get("/v1/market-data/stocks")
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check response structure
+    assert "timestamp" in data
+    assert "stocks" in data
+
+    # Check mock data is returned
+    stocks = data["stocks"]
+    assert len(stocks) == 4
+
+    # Verify expected stocks are present (from conftest.py mock)
+    expected_stocks = [
+        {"ticker": "AAPL", "company_name": "Apple Inc."},
+        {"ticker": "GOOGL", "company_name": "Alphabet Inc."},
+        {"ticker": "MSFT", "company_name": "Microsoft Corporation"},
+        {"ticker": "TSLA", "company_name": "Tesla Inc."},
+    ]
+
+    for expected_stock in expected_stocks:
+        assert expected_stock in stocks
+
+    # Verify stocks are sorted by ticker (from ORDER BY in query)
+    tickers = [stock["ticker"] for stock in stocks]
+    assert tickers == sorted(tickers)


### PR DESCRIPTION
# Summary

- Added an endpoint, GET `/v1/market-data/stocks`, to return all stocks from the DB
- Added all stocks as options in the stock selector for the single stock view

<img width="949" alt="image" src="https://github.com/user-attachments/assets/6b197c10-9a42-4564-a75d-2057bed89d3a" />

## Related Issues

- #41 