### PR TITLE
feat: Add manual order submission form

### DIFF
--- a/src/order_book_simulator/ui/components/api_client.py
+++ b/src/order_book_simulator/ui/components/api_client.py
@@ -124,14 +124,21 @@ def submit_order(order_data: dict) -> dict | None:
             return response.json()
         # Validation error
         elif response.status_code == 422:
-            error_detail = response.json().get("detail", "Validation error")
+            try:
+                error_detail = response.json().get("detail", "Validation error")
+            except ValueError:
+                error_detail = f"Validation error (HTTP {response.status_code})"
             st.error(f"Order validation failed: {error_detail}")
             return None
+        # Other non-200 status codes
         else:
             st.error(f"Failed to submit order: {response.status_code}")
             if response.content:
-                error_msg = response.json().get("detail", "Unknown error")
-                st.error(f"Error details: {error_msg}")
+                try:
+                    error_msg = response.json().get("detail", "Unknown error")
+                    st.error(f"Error details: {error_msg}")
+                except ValueError:
+                    st.error(f"Validation error (HTTP {response.status_code})")
             return None
     except Exception as e:
         st.error(f"Error submitting order: {e}")

--- a/src/order_book_simulator/ui/components/api_client.py
+++ b/src/order_book_simulator/ui/components/api_client.py
@@ -104,3 +104,35 @@ def get_all_stocks() -> dict | None:
     except Exception as e:
         st.error(f"Error fetching stocks: {e}")
         return None
+
+
+def submit_order(order_data: dict) -> dict | None:
+    """
+    Submits an order to the order book system.
+
+    Args:
+        order_data: Dictionary containing order information
+
+    Returns:
+        Order response dictionary or None if submission failed
+    """
+    try:
+        response = requests.post(
+            f"{GATEWAY_URL}/v1/order-book", json=order_data, timeout=10
+        )
+        if response.status_code == 200:
+            return response.json()
+        # Validation error
+        elif response.status_code == 422:
+            error_detail = response.json().get("detail", "Validation error")
+            st.error(f"Order validation failed: {error_detail}")
+            return None
+        else:
+            st.error(f"Failed to submit order: {response.status_code}")
+            if response.content:
+                error_msg = response.json().get("detail", "Unknown error")
+                st.error(f"Error details: {error_msg}")
+            return None
+    except Exception as e:
+        st.error(f"Error submitting order: {e}")
+        return None

--- a/src/order_book_simulator/ui/components/api_client.py
+++ b/src/order_book_simulator/ui/components/api_client.py
@@ -138,7 +138,7 @@ def submit_order(order_data: dict) -> dict | None:
                     error_msg = response.json().get("detail", "Unknown error")
                     st.error(f"Error details: {error_msg}")
                 except ValueError:
-                    st.error(f"Validation error (HTTP {response.status_code})")
+                    st.error(f"Error (HTTP {response.status_code})")
             return None
     except Exception as e:
         st.error(f"Error submitting order: {e}")

--- a/src/order_book_simulator/ui/components/order_form.py
+++ b/src/order_book_simulator/ui/components/order_form.py
@@ -68,11 +68,14 @@ def create_order_form() -> None:
                     help="Price per share for limit orders",
                 )
 
+        # Persist the user ID in session state for consistency
+        if "user_id" not in st.session_state:
+            st.session_state.user_id = str(uuid4())
         # User ID at bottom left (simplified for demo)
         user_id = st.text_input(
             "User ID",
-            value=str(uuid4()),
-            help="Unique identifier for the user (auto-generated)",
+            value=st.session_state.user_id,
+            help="Unique identifier for the user (persists for this session)",
         )
 
         # Submit button

--- a/src/order_book_simulator/ui/components/order_form.py
+++ b/src/order_book_simulator/ui/components/order_form.py
@@ -1,0 +1,117 @@
+from uuid import uuid4
+
+import streamlit as st
+
+from order_book_simulator.ui.components.api_client import (
+    get_all_stocks,
+    submit_order,
+)
+
+
+def create_order_form() -> None:
+    """
+    Creates a manual order submission form with validation.
+    """
+    st.subheader("Submit Order")
+
+    # Get available stocks for the dropdown
+    stocks_data = get_all_stocks()
+    stock_options = []
+    if stocks_data and stocks_data.get("stocks"):
+        stock_options = [stock["ticker"] for stock in stocks_data["stocks"]]
+
+    # Fallback to hardcoded options if API unavailable
+    if not stock_options:
+        stock_options = ["AAPL", "AMZN", "GOOGL", "META", "MSFT", "NVDA", "TSLA"]
+
+    # Order type selection outside form for dynamic UI updates
+    order_type = st.selectbox(
+        "Order Type",
+        ["LIMIT", "MARKET"],
+        help="Limit orders specify a price, market orders execute immediately",
+    )
+
+    with st.form("order_form"):
+        col1, col2 = st.columns(2)
+
+        with col1:
+            # Stock selection
+            ticker = st.selectbox(
+                "Stock", stock_options, help="Select the stock you want to trade"
+            )
+
+            # Order side
+            side = st.selectbox(
+                "Side", ["BUY", "SELL"], help="Choose whether to buy or sell"
+            )
+
+        with col2:
+            # Quantity
+            quantity = st.number_input(
+                "Quantity",
+                min_value=0.01,
+                value=1.0,
+                step=0.01,
+                format="%.2f",
+                help="Number of shares to trade",
+            )
+
+            # Price (only show for limit orders)
+            price = None
+            if order_type == "LIMIT":
+                price = st.number_input(
+                    "Price ($)",
+                    min_value=0.01,
+                    value=100.0,
+                    step=0.01,
+                    format="%.2f",
+                    help="Price per share for limit orders",
+                )
+
+        # User ID at bottom left (simplified for demo)
+        user_id = st.text_input(
+            "User ID",
+            value=str(uuid4()),
+            help="Unique identifier for the user (auto-generated)",
+        )
+
+        # Submit button
+        submitted = st.form_submit_button("Submit Order", type="primary")
+
+        if submitted:
+            # Validate inputs
+            errors = []
+            if not ticker:
+                errors.append("Please select a stock")
+            if quantity <= 0:
+                errors.append("Quantity must be greater than 0")
+            if order_type == "LIMIT" and (price is None or price <= 0):
+                errors.append("Price must be greater than 0 for limit orders")
+            if not user_id:
+                errors.append("User ID is required")
+
+            # Stop early if any validation failed
+            if errors:
+                for error in errors:
+                    st.error(error)
+                return
+
+            # Submit the order
+            order_data = {
+                "user_id": user_id,
+                "ticker": ticker,
+                "type": order_type,
+                "side": side,
+                "quantity": str(quantity),
+                "price": str(price) if price is not None else None,
+            }
+            with st.spinner("Submitting order..."):
+                response = submit_order(order_data)
+            if response:
+                st.success(
+                    "Order submitted successfully! "
+                    f"Order ID: {response.get('id', 'N/A')}"
+                )
+                st.json(response)
+            else:
+                st.error("Failed to submit order. Please try again.")

--- a/src/order_book_simulator/ui/streamlit_app.py
+++ b/src/order_book_simulator/ui/streamlit_app.py
@@ -14,6 +14,7 @@ from order_book_simulator.ui.components.order_book import (
     create_auto_refresh_order_book,
     display_single_stock_order_book,
 )
+from order_book_simulator.ui.components.order_form import create_order_form
 
 
 def main():
@@ -48,13 +49,14 @@ def main():
         "View Mode",
         [
             "Market Overview",
-            "Single Stock",
+            "Order Book for Single Stock",
+            "Submit Order",
         ],
     )
 
     # Stock selection (only shown for single stock view)
     ticker = None
-    if view_mode == "Single Stock":
+    if view_mode == "Order Book for Single Stock":
         # Fetch all stocks from database
         stocks_data = get_all_stocks()
         if stocks_data and stocks_data.get("stocks"):
@@ -98,12 +100,17 @@ def main():
             auto_refresh_fragment()
         else:
             create_market_overview()
-    elif view_mode == "Single Stock" and ticker:
+    elif view_mode == "Order Book for Single Stock" and ticker:
         if auto_refresh_enabled:
             auto_refresh_fragment = create_auto_refresh_order_book(refresh_interval)
             auto_refresh_fragment(ticker)
         else:
             display_single_stock_order_book(ticker)
+    elif view_mode == "Submit Order":
+        if gateway_connected:
+            create_order_form()
+        else:
+            st.error("Gateway connection required to submit orders")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary

- Added a manual order submission form using the POST `/v1/order-book` endpoint
  - Supports both limit and market orders
- Note that we automatically generate a user ID and save this in Streamlit's session state for consistency

## Related Issues

- Fixes #41 

## Screenshots

<img width="956" alt="image" src="https://github.com/user-attachments/assets/dc53cc9a-d222-4c8d-87f2-da49669210b3" />


<img width="957" alt="image" src="https://github.com/user-attachments/assets/99e1f650-4b32-40e3-af19-61d8ebab885b" />
