### PR TITLE
fix: Tighten error policy in order consumer

### DIFF
--- a/src/order_book_simulator/matching/order_consumer.py
+++ b/src/order_book_simulator/matching/order_consumer.py
@@ -12,6 +12,18 @@ from order_book_simulator.multicast.multicast_publisher import MulticastPublishe
 
 logger = logging.getLogger(__name__)
 
+# Exceptions that indicate the message itself is malformed or unknown.
+# These are skipped with structured context - retrying won't help.
+# Anything outside this tuple is treated as a bug or infrastructure
+# failure and is allowed to propagate, crashing the consumer so the
+# supervisor restarts it rather than silently processing bad state.
+RECOVERABLE_ERRORS = (
+    orjson.JSONDecodeError,
+    KeyError,
+    ValueError,
+    TypeError,
+)
+
 
 class OrderConsumer:
     """Processes incoming orders from Kafka and routes them to the matching engine."""
@@ -54,15 +66,19 @@ class OrderConsumer:
         """
         Processes a single message from Kafka.
 
+        Malformed or unknown messages are logged with full context and
+        skipped. Unexpected errors propagate so the consumer crashes
+        rather than processing bad state silently.
+
         Args:
             message: The message received from Kafka.
         """
+        order_id: str | None = None
         try:
             if message.value is None:
                 return
             order_data = orjson.loads(message.value)
 
-            # Skip health check messages
             match order_data.get("type"):
                 case "health_check":
                     return
@@ -100,9 +116,46 @@ class OrderConsumer:
                         f"total_latency={total_latency:.2f}ms"
                     )
                 case _:
-                    raise ValueError(f"Unknown order type: {order_data.get('type')}")
-        except Exception as e:
-            logger.error(f"Error processing message: {e}")
+                    raise ValueError(f"Unknown order type: {order_data.get('type')!r}")
+        except RECOVERABLE_ERRORS as e:
+            self._log_skipped_message(message, e, order_id)
+
+    def _log_skipped_message(
+        self,
+        message: ConsumerRecord,
+        error: Exception,
+        order_id: str | None,
+    ) -> None:
+        """
+        Logs a malformed Kafka message with the full context needed
+        to debug or replay it.
+
+        Args:
+            message: The Kafka message that failed to process.
+            error: The recoverable exception raised while processing.
+            order_id: The parsed order ID if available, else None.
+        """
+        # Truncate the payload to keep log lines bounded; replace bad
+        # bytes so a broken UTF-8 payload still logs cleanly.
+        payload_repr = (
+            message.value[:500].decode("utf-8", errors="replace")
+            if message.value
+            else None
+        )
+        key_repr = (
+            message.key.decode("utf-8", errors="replace") if message.key else None
+        )
+        logger.error(
+            "Skipping malformed Kafka message: "
+            f"error_type={type(error).__name__}, "
+            f"error={error!s}, "
+            f"topic={message.topic}, "
+            f"partition={message.partition}, "
+            f"offset={message.offset}, "
+            f"key={key_repr!r}, "
+            f"order_id={order_id!r}, "
+            f"payload={payload_repr!r}"
+        )
 
     async def start(self) -> None:
         """Starts consuming order messages with retry logic."""
@@ -112,6 +165,10 @@ class OrderConsumer:
             group_id=self.group_id,
             session_timeout_ms=self.session_timeout_ms,
             heartbeat_interval_ms=self.heartbeat_interval_ms,
+            # Disable auto-commit so offsets only advance after a
+            # message is handled (or deliberately skipped). Prevents
+            # silent data loss when processing raises.
+            enable_auto_commit=False,
         )
 
         for attempt in range(self.max_retries):
@@ -138,6 +195,10 @@ class OrderConsumer:
         try:
             async for message in self.consumer:
                 await self._process_message(message)
+                # Commit only after _process_message returns. Unexpected
+                # exceptions skip this and bubble up, so the message is
+                # reprocessed after the consumer restarts.
+                await self.consumer.commit()
         except Exception as e:
             logger.error(f"Error consuming messages: {str(e)}")
             raise

--- a/tests/test_matching/test_order_consumer.py
+++ b/tests/test_matching/test_order_consumer.py
@@ -1,0 +1,192 @@
+from datetime import datetime, timezone
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import orjson
+import pytest
+from aiokafka import ConsumerRecord
+
+from order_book_simulator.matching.matching_engine import MatchingEngine
+from order_book_simulator.matching.order_consumer import OrderConsumer
+
+
+def make_record(value: bytes | None, key: bytes | None = None) -> ConsumerRecord:
+    """Builds a minimal ConsumerRecord for tests."""
+    return ConsumerRecord(
+        topic="orders",
+        partition=0,
+        offset=42,
+        timestamp=0,
+        timestamp_type=0,
+        key=key,
+        value=value,
+        checksum=None,
+        serialized_key_size=-1,
+        serialized_value_size=-1,
+        headers=(),
+    )
+
+
+@pytest.fixture
+def engine() -> AsyncMock:
+    """Creates an AsyncMock standing in for the matching engine."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def consumer(engine: AsyncMock) -> OrderConsumer:
+    """Creates an OrderConsumer wired to the mocked matching engine."""
+    return OrderConsumer(matching_engine=cast(MatchingEngine, engine))
+
+
+@pytest.mark.asyncio
+async def test_process_order_message_calls_matching_engine(
+    consumer: OrderConsumer, engine: AsyncMock
+):
+    """Tests that a well-formed order is forwarded to the matching engine."""
+    order_id = str(uuid4())
+    payload = orjson.dumps(
+        {
+            "type": "order",
+            "id": order_id,
+            "stock_id": str(uuid4()),
+            "ticker": "AAPL",
+            "side": "BUY",
+            "order_type": "LIMIT",
+            "price": "100",
+            "quantity": "10",
+            "gateway_received_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    await consumer._process_message(make_record(payload))
+
+    engine.process_order.assert_awaited_once()
+    forwarded = engine.process_order.await_args.args[0]
+    assert forwarded["id"] == order_id
+
+
+@pytest.mark.asyncio
+async def test_process_cancel_message_calls_cancel(
+    consumer: OrderConsumer, engine: AsyncMock
+):
+    """Tests that a cancel message is routed to cancel_order."""
+    payload = orjson.dumps(
+        {
+            "type": "cancel",
+            "order_id": str(uuid4()),
+            "stock_id": str(uuid4()),
+            "ticker": "AAPL",
+        }
+    )
+    await consumer._process_message(make_record(payload))
+
+    engine.cancel_order.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_is_skipped(consumer: OrderConsumer, engine: AsyncMock):
+    """Tests that health check messages are silently ignored."""
+    payload = orjson.dumps({"type": "health_check"})
+    await consumer._process_message(make_record(payload))
+
+    engine.process_order.assert_not_awaited()
+    engine.cancel_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_is_skipped_with_context(
+    consumer: OrderConsumer,
+    engine: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Tests that invalid JSON is logged with full context and does not raise."""
+    caplog.set_level("ERROR")
+    record = make_record(b"not valid json{{{", key=b"some-key")
+
+    # Should not raise - this is a recoverable error.
+    await consumer._process_message(record)
+
+    engine.process_order.assert_not_awaited()
+    assert "Skipping malformed Kafka message" in caplog.text
+    assert "topic=orders" in caplog.text
+    assert "partition=0" in caplog.text
+    assert "offset=42" in caplog.text
+    assert "key='some-key'" in caplog.text
+    assert "JSONDecodeError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_order_type_is_skipped(
+    consumer: OrderConsumer,
+    engine: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Tests that an unrecognised type is logged and skipped, not raised."""
+    caplog.set_level("ERROR")
+    payload = orjson.dumps({"type": "definitely-not-real"})
+
+    await consumer._process_message(make_record(payload))
+
+    assert "Unknown order type" in caplog.text
+    assert "ValueError" in caplog.text
+    engine.process_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_required_field_is_skipped_with_order_id(
+    consumer: OrderConsumer, caplog: pytest.LogCaptureFixture
+):
+    """Tests that a missing field after parsing the order ID logs the ID."""
+    caplog.set_level("ERROR")
+    order_id = str(uuid4())
+    # Missing gateway_received_at - KeyError after order_id is set.
+    payload = orjson.dumps({"type": "order", "id": order_id})
+
+    await consumer._process_message(make_record(payload))
+
+    assert "KeyError" in caplog.text
+    assert f"order_id='{order_id}'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_propagates(
+    consumer: OrderConsumer, engine: AsyncMock
+):
+    """
+    Tests that a non-recoverable exception (e.g. matching engine crash)
+    propagates out of _process_message rather than being swallowed.
+    """
+    engine.process_order.side_effect = RuntimeError("matching engine exploded")
+    payload = orjson.dumps(
+        {
+            "type": "order",
+            "id": str(uuid4()),
+            "stock_id": str(uuid4()),
+            "ticker": "AAPL",
+            "side": "BUY",
+            "order_type": "LIMIT",
+            "price": "100",
+            "quantity": "10",
+            "gateway_received_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="matching engine exploded"):
+        await consumer._process_message(make_record(payload))
+
+
+@pytest.mark.asyncio
+async def test_truncates_oversized_payload_in_log(
+    consumer: OrderConsumer, caplog: pytest.LogCaptureFixture
+):
+    """Tests that an oversized malformed payload is truncated in the log."""
+    caplog.set_level("ERROR")
+    # 2 KB of junk - should be truncated to 500 chars in the log.
+    payload = b"x" * 2048
+
+    await consumer._process_message(make_record(payload))
+
+    # The truncated payload representation appears, not the full 2 KB.
+    assert "payload='" in caplog.text
+    assert "x" * 2049 not in caplog.text


### PR DESCRIPTION
# Summary

- Replaced the order consumer's silent `except Exception` with an explicit policy that splits recoverable input failures from unexpected errors
  - Recoverable failures (malformed payloads, unknown order types, missing fields) skip the message with full structured context in the log – topic, partition, offset, key, parsed order ID, truncated payload
  - Unexpected failures propagate so the supervisor restarts the consumer rather than advancing offsets over bad matching engine state
- Disabled `enable_auto_commit` and added an explicit `consumer.commit()` after each handled message – offsets no longer move silently when processing raises
- Added test coverage for the happy paths and every failure bucket