### PR TITLE
fix: Tighten gateway and matcher order validation

### DIFF
--- a/src/order_book_simulator/gateway/producer.py
+++ b/src/order_book_simulator/gateway/producer.py
@@ -150,7 +150,11 @@ class OrderProducer:
             "ticker": order_record["ticker"],
             "order_type": order_record["type"].value,
             "side": order_record["side"].value,
-            "price": str(order_record["price"]) if order_record["price"] else None,
+            "price": (
+                str(order_record["price"])
+                if order_record["price"] is not None
+                else None
+            ),
             "quantity": str(order_record["quantity"]),
             "gateway_received_at": order_record["gateway_received_at"],
         }

--- a/src/order_book_simulator/gateway/validation.py
+++ b/src/order_book_simulator/gateway/validation.py
@@ -1,9 +1,19 @@
+from decimal import Decimal
+
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from order_book_simulator.common.models import OrderRequest, OrderType
 from order_book_simulator.database.db_models import Stock
 from order_book_simulator.database.queries import get_stock_by_ticker
+
+SUPPORTED_ORDER_TYPES = frozenset({OrderType.LIMIT, OrderType.MARKET})
+
+
+def _has_valid_price_precision(price: Decimal, price_precision: int) -> bool:
+    """Return whether a price is on the stock's configured tick size."""
+    tick_size = Decimal("1").scaleb(-price_precision)
+    return price == price.quantize(tick_size)
 
 
 async def validate_order(order_request: OrderRequest, db: AsyncSession) -> Stock:
@@ -21,15 +31,28 @@ async def validate_order(order_request: OrderRequest, db: AsyncSession) -> Stock
     Returns:
         The validated Stock object.
     """
-    # Look up stock by ticker
+    # Look up stock by ticker.
     stock = await get_stock_by_ticker(order_request.ticker, db)
     if not stock:
         raise HTTPException(
             status_code=404, detail=f"Stock ticker {order_request.ticker} not found"
         )
 
-    # Validate order size (must be whole number of shares)
-    if not float(order_request.quantity).is_integer():
+    if order_request.type not in SUPPORTED_ORDER_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{order_request.type.value} orders are not supported",
+        )
+
+    # Validate order size. US equity share quantities must be positive whole
+    # numbers in this simulator.
+    if not order_request.quantity.is_finite() or order_request.quantity <= Decimal("0"):
+        raise HTTPException(
+            status_code=400,
+            detail="Order quantity must be positive",
+        )
+
+    if order_request.quantity != order_request.quantity.to_integral_value():
         raise HTTPException(
             status_code=400,
             detail="Order quantity must be a whole number of shares",
@@ -47,8 +70,31 @@ async def validate_order(order_request: OrderRequest, db: AsyncSession) -> Stock
             ),
         )
 
+    if order_request.type == OrderType.MARKET:
+        if order_request.price is not None:
+            raise HTTPException(
+                status_code=400,
+                detail="Market orders must not specify a price",
+            )
+        return stock
+
     # Validate price for limit orders.
-    if order_request.type == OrderType.LIMIT and not order_request.price:
+    if order_request.price is None:
         raise HTTPException(status_code=400, detail="Limit orders must specify a price")
+
+    if not order_request.price.is_finite() or order_request.price <= Decimal("0"):
+        raise HTTPException(
+            status_code=400,
+            detail="Limit order price must be positive",
+        )
+
+    if not _has_valid_price_precision(order_request.price, stock.price_precision):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Limit order price must use at most {stock.price_precision} "
+                "decimal places"
+            ),
+        )
 
     return stock

--- a/src/order_book_simulator/matching/order_book.py
+++ b/src/order_book_simulator/matching/order_book.py
@@ -20,6 +20,8 @@ class OrderBook:
     Manages the limit order book for a single stock.
     """
 
+    SUPPORTED_ORDER_TYPES = frozenset({OrderType.LIMIT, OrderType.MARKET})
+
     def __init__(self, stock_id: UUID, ticker: str):
         self.stock_id: UUID = stock_id
         self.ticker: str = ticker
@@ -47,23 +49,11 @@ class OrderBook:
         Returns:
             A list of fills from matching the order.
         """
+        trades: list[FilledOrder] = []
+
         # Exit early if there are no opposing levels to match against.
         if not opposing_levels:
             return []
-
-        trades: list[FilledOrder] = []
-
-        # Only limit orders should have a price.
-        if (
-            incoming_order.order_type == OrderType.MARKET
-            and incoming_order.price is not None
-        ):
-            raise ValueError("Market orders should not have a price.")
-        if (
-            incoming_order.order_type == OrderType.LIMIT
-            and incoming_order.price is None
-        ):
-            raise ValueError("Limit orders must have a price.")
 
         # Track the price levels that need to be removed after matching.
         levels_to_remove: list[Decimal] = []
@@ -73,7 +63,7 @@ class OrderBook:
                 break
 
             # Check if the price level can match.
-            if incoming_order.price:
+            if incoming_order.price is not None:
                 if is_buy and price > incoming_order.price:
                     break
                 if not is_buy and price < incoming_order.price:
@@ -157,6 +147,40 @@ class OrderBook:
 
         return trades
 
+    def _validate_order(
+        self,
+        order_type: OrderType,
+        quantity: Decimal,
+        price: Decimal | None,
+    ) -> None:
+        """
+        Validates order semantics before the order can mutate the book.
+
+        Args:
+            order_type: The order type to validate.
+            quantity: The requested quantity.
+            price: The optional limit price.
+
+        Raises:
+            ValueError: If the order cannot be handled by the matching engine.
+        """
+        if order_type not in self.SUPPORTED_ORDER_TYPES:
+            raise ValueError(f"{order_type.value} orders are not supported.")
+
+        if not quantity.is_finite() or quantity <= Decimal("0"):
+            raise ValueError("Order quantity must be positive.")
+
+        if order_type == OrderType.MARKET:
+            if price is not None:
+                raise ValueError("Market orders should not have a price.")
+            return
+
+        if price is None:
+            raise ValueError("Limit orders must have a price.")
+
+        if not price.is_finite() or price <= Decimal("0"):
+            raise ValueError("Limit order price must be positive.")
+
     def add_order(self, order: dict[str, Any]) -> list[dict]:
         """
         Processes an incoming order, matching it against existing orders and
@@ -178,14 +202,16 @@ class OrderBook:
             order_type = OrderType(order_type)
             order["order_type"] = order_type
         is_buy = side == OrderSide.BUY
-        price = Decimal(order["price"]) if order.get("price") is not None else None
+        price = Decimal(str(order["price"])) if order.get("price") is not None else None
+        quantity = Decimal(str(order["quantity"]))
+        self._validate_order(order_type, quantity, price)
 
         # Create an OrderBookEntry from the incoming order dict.
         incoming_order = OrderBookEntry(
             id=order["id"],
             order_type=order_type,
             side=side,
-            quantity=Decimal(order["quantity"]),
+            quantity=quantity,
             price=price,
             entry_time=int(order["created_at"].timestamp() * 1_000_000),
         )
@@ -199,7 +225,7 @@ class OrderBook:
         # If it's a limit order and there's remaining quantity, add it to the
         # book.
         if order_type == OrderType.LIMIT and incoming_order.quantity > 0:
-            if not price:
+            if price is None:
                 raise ValueError("Limit orders must have a price.")
 
             price_levels = self.bid_levels if is_buy else self.ask_levels
@@ -250,7 +276,7 @@ class OrderBook:
         levels: SortedDict[Decimal, PriceLevel] = (
             self.bid_levels if order.side == OrderSide.BUY else self.ask_levels
         )
-        if order.price and order.price in levels:
+        if order.price is not None and order.price in levels:
             price_level: PriceLevel = levels[order.price]
             if order_id in price_level.orders:
                 del price_level.orders[order_id]

--- a/tests/test_gateway/test_validation.py
+++ b/tests/test_gateway/test_validation.py
@@ -1,0 +1,149 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from order_book_simulator.common.models import OrderRequest, OrderSide, OrderType
+from order_book_simulator.gateway import validation as validation_module
+from order_book_simulator.gateway.validation import validate_order
+
+
+def _stock(price_precision: int = 2) -> SimpleNamespace:
+    """Create a stock-like object for validation tests."""
+    return SimpleNamespace(
+        id=uuid4(),
+        ticker="AAPL",
+        min_order_size=Decimal("1"),
+        max_order_size=Decimal("1000"),
+        price_precision=price_precision,
+    )
+
+
+def _order(
+    order_type: OrderType = OrderType.LIMIT,
+    price: Decimal | None = Decimal("100.00"),
+    quantity: Decimal = Decimal("10"),
+) -> OrderRequest:
+    """Create a valid base order request for validation tests."""
+    return OrderRequest(
+        user_id=uuid4(),
+        ticker="AAPL",
+        type=order_type,
+        side=OrderSide.BUY,
+        price=price,
+        quantity=quantity,
+    )
+
+
+def _db() -> AsyncSession:
+    """Create a typed mock database session."""
+    return cast(AsyncSession, AsyncMock(spec=AsyncSession))
+
+
+@pytest.fixture
+def stock_lookup(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    """Patch stock lookup to return a known stock."""
+    stock = _stock()
+
+    async def mock_get_stock_by_ticker(ticker, db):
+        return stock
+
+    monkeypatch.setattr(
+        validation_module,
+        "get_stock_by_ticker",
+        mock_get_stock_by_ticker,
+    )
+    return stock
+
+
+@pytest.mark.asyncio
+async def test_validate_order_accepts_valid_limit_order(stock_lookup):
+    """Validates a correctly formed limit order."""
+    stock = await validate_order(_order(), db=_db())
+
+    assert stock is stock_lookup
+
+
+@pytest.mark.asyncio
+async def test_validate_order_accepts_valid_market_order(stock_lookup):
+    """Validates a correctly formed market order."""
+    stock = await validate_order(_order(OrderType.MARKET, price=None), db=_db())
+
+    assert stock is stock_lookup
+
+
+@pytest.mark.asyncio
+async def test_validate_order_rejects_stop_orders(stock_lookup):
+    """Rejects stop orders until stop-trigger state exists."""
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_order(_order(OrderType.STOP), db=_db())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "STOP orders are not supported"
+
+
+@pytest.mark.asyncio
+async def test_validate_order_rejects_market_orders_with_price(stock_lookup):
+    """Rejects market orders that incorrectly provide a price."""
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_order(_order(OrderType.MARKET, price=Decimal("100")), db=_db())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Market orders must not specify a price"
+
+
+@pytest.mark.asyncio
+async def test_validate_order_rejects_limit_orders_without_price(stock_lookup):
+    """Rejects limit orders that do not provide a limit price."""
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_order(_order(price=None), db=_db())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Limit orders must specify a price"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("price", [Decimal("0"), Decimal("-1")])
+async def test_validate_order_rejects_non_positive_limit_price(
+    stock_lookup,
+    price: Decimal,
+):
+    """Rejects zero and negative limit prices."""
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_order(_order(price=price), db=_db())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Limit order price must be positive"
+
+
+@pytest.mark.asyncio
+async def test_validate_order_rejects_invalid_price_precision(stock_lookup):
+    """Rejects prices outside the stock's configured tick size."""
+    stock_lookup.price_precision = 2
+
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_order(_order(price=Decimal("100.001")), db=_db())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == (
+        "Limit order price must use at most 2 decimal places"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quantity", [Decimal("0"), Decimal("-1")])
+async def test_validate_order_rejects_non_positive_quantity(
+    stock_lookup,
+    quantity: Decimal,
+):
+    """Rejects zero and negative quantities."""
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_order(_order(quantity=quantity), db=_db())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Order quantity must be positive"

--- a/tests/test_matching/test_order_book.py
+++ b/tests/test_matching/test_order_book.py
@@ -165,6 +165,62 @@ def test_market_order_with_price_raises_error(order_book: OrderBook) -> None:
         order_book.add_order(market_buy)
 
 
+def test_market_order_with_price_raises_on_empty_book(order_book: OrderBook) -> None:
+    """Tests that invalid market orders are rejected before liquidity checks."""
+    market_buy = create_order(
+        price=Decimal("100"),
+        quantity=Decimal("5"),
+        order_type=OrderType.MARKET,
+    )
+
+    with pytest.raises(ValueError, match="Market orders should not have a price"):
+        order_book.add_order(market_buy)
+
+
+def test_stop_order_raises_error(order_book: OrderBook) -> None:
+    """Tests that unsupported stop orders are rejected."""
+    stop_order = create_order(
+        price=Decimal("100"),
+        quantity=Decimal("5"),
+        order_type=OrderType.STOP,
+    )
+
+    with pytest.raises(ValueError, match="STOP orders are not supported"):
+        order_book.add_order(stop_order)
+
+
+def test_limit_order_without_price_raises_error(order_book: OrderBook) -> None:
+    """Tests that limit orders must provide a price."""
+    order = create_order(price=None, quantity=Decimal("5"))
+
+    with pytest.raises(ValueError, match="Limit orders must have a price"):
+        order_book.add_order(order)
+
+
+@pytest.mark.parametrize("price", [Decimal("0"), Decimal("-1")])
+def test_limit_order_with_non_positive_price_raises_error(
+    order_book: OrderBook,
+    price: Decimal,
+) -> None:
+    """Tests that limit order prices must be positive."""
+    order = create_order(price=price, quantity=Decimal("5"))
+
+    with pytest.raises(ValueError, match="Limit order price must be positive"):
+        order_book.add_order(order)
+
+
+@pytest.mark.parametrize("quantity", [Decimal("0"), Decimal("-1")])
+def test_order_with_non_positive_quantity_raises_error(
+    order_book: OrderBook,
+    quantity: Decimal,
+) -> None:
+    """Tests that orders must have a positive quantity."""
+    order = create_order(price=Decimal("100"), quantity=quantity)
+
+    with pytest.raises(ValueError, match="Order quantity must be positive"):
+        order_book.add_order(order)
+
+
 def test_cancel_order_success(order_book: OrderBook) -> None:
     """Tests successful order cancellation."""
     order = create_order(price=Decimal("100"), quantity=Decimal("10"))


### PR DESCRIPTION
# Summary
- Tightened order validation at the API boundary for unsupported order types, malformed market orders, limit price requirements, tick precision, and invalid quantities
- Added matcher-side validation before orders can match or mutate the book
  - Kept the matcher defensive for direct calls that bypass the gateway
  - Prevented invalid market orders from slipping through empty-book paths
- Replaced Decimal truthiness checks around prices with explicit `None` checks so zero-like values cannot be misclassified
- Added regression coverage across gateway and matcher validation paths

## Rationale
- Validation now lives at both the gateway and matcher because the matcher is callable independently of FastAPI – the API should reject bad requests, but the engine still needs to protect book state from internal or replayed input
- Explicit `None` checks avoid conflating a missing price with falsy numeric values – this was the latent issue behind zero prices and market order prices being handled inconsistently
