### PR TITLE
fix: Preserve offsets when matching engine fails

### DIFF
--- a/src/order_book_simulator/matching/order_consumer.py
+++ b/src/order_book_simulator/matching/order_consumer.py
@@ -1,24 +1,27 @@
 import asyncio
 import logging
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from uuid import UUID
 
 import orjson
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer, ConsumerRecord
 from redis.asyncio import Redis
 
+from order_book_simulator.common.models import OrderSide, OrderType
 from order_book_simulator.market_data.analytics import MarketDataAnalytics
 from order_book_simulator.matching.matching_engine import MatchingEngine
 from order_book_simulator.multicast.multicast_publisher import MulticastPublisher
 
 logger = logging.getLogger(__name__)
 
-# Exceptions that indicate the message itself is malformed or unknown.
-# These are skipped with structured context - retrying won't help.
-# Anything outside this tuple is treated as a bug or infrastructure
-# failure and is allowed to propagate, crashing the consumer so the
-# supervisor restarts it rather than silently processing bad state.
-RECOVERABLE_ERRORS = (
+# Exceptions that indicate the Kafka message cannot be parsed or does
+# not match the consumer envelope contract. These are skipped with
+# structured context because retrying the same bytes will not help.
+MALFORMED_MESSAGE_ERRORS = (
     orjson.JSONDecodeError,
+    InvalidOperation,
     KeyError,
     ValueError,
     TypeError,
@@ -62,6 +65,132 @@ class OrderConsumer:
         self.session_timeout_ms = session_timeout_ms
         self.heartbeat_interval_ms = heartbeat_interval_ms
 
+    @staticmethod
+    def _decode_message_payload(value: bytes) -> dict[str, Any]:
+        """Decode a Kafka payload into a JSON object.
+
+        Args:
+            value: The raw Kafka message value.
+
+        Returns:
+            The decoded JSON object.
+
+        Raises:
+            TypeError: If the payload is not a JSON object.
+        """
+        order_data = orjson.loads(value)
+        if not isinstance(order_data, dict):
+            raise TypeError("Kafka message payload must be a JSON object")
+        return order_data
+
+    @staticmethod
+    def _require_string(order_data: dict[str, Any], field: str) -> str:
+        """Return a required non-empty string field from a Kafka message.
+
+        Args:
+            order_data: The decoded Kafka message.
+            field: The field name to read.
+
+        Returns:
+            The validated string value.
+
+        Raises:
+            KeyError: If the field is missing.
+            TypeError: If the field is not a non-empty string.
+        """
+        value = order_data[field]
+        if not isinstance(value, str) or not value:
+            raise TypeError(f"{field} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _validate_uuid(value: str, field: str) -> None:
+        """Validate that a string field contains a UUID.
+
+        Args:
+            value: The candidate UUID string.
+            field: The source field name used in error messages.
+
+        Raises:
+            ValueError: If the value is not a UUID.
+        """
+        try:
+            UUID(value)
+        except ValueError as exc:
+            raise ValueError(f"{field} must be a UUID") from exc
+
+    @staticmethod
+    def _validate_decimal(value: Any, field: str) -> None:
+        """Validate that a field can be parsed as a decimal value.
+
+        Args:
+            value: The candidate decimal value.
+            field: The source field name used in error messages.
+
+        Raises:
+            TypeError: If the value is null.
+            InvalidOperation: If the value cannot be parsed as a Decimal.
+        """
+        if value is None:
+            raise TypeError(f"{field} must not be null")
+        Decimal(str(value))
+
+    @staticmethod
+    def _parse_gateway_time(order_data: dict[str, Any]) -> datetime:
+        """Parse the gateway timestamp from an order message.
+
+        Args:
+            order_data: The decoded order message.
+
+        Returns:
+            The parsed gateway timestamp.
+
+        Raises:
+            ValueError: If the timestamp is invalid or timezone-naive.
+        """
+        raw_gateway_time = OrderConsumer._require_string(
+            order_data, "gateway_received_at"
+        )
+        gateway_time = datetime.fromisoformat(raw_gateway_time)
+        if gateway_time.tzinfo is None:
+            raise ValueError("gateway_received_at must include a timezone")
+        return gateway_time
+
+    def _validate_order_message(self, order_data: dict[str, Any]) -> datetime:
+        """Validate an order message before handing it to the engine.
+
+        This only validates the Kafka envelope and parseable field types.
+        Matching-domain validation belongs to the matching engine so those
+        failures propagate instead of being committed as skipped messages.
+
+        Args:
+            order_data: The decoded order message.
+
+        Returns:
+            The parsed gateway timestamp used for latency logging.
+        """
+        self._validate_uuid(self._require_string(order_data, "id"), "id")
+        self._validate_uuid(self._require_string(order_data, "stock_id"), "stock_id")
+        self._require_string(order_data, "ticker")
+        OrderSide(self._require_string(order_data, "side"))
+        OrderType(self._require_string(order_data, "order_type"))
+        self._validate_decimal(order_data["quantity"], "quantity")
+        if "price" not in order_data:
+            raise KeyError("price")
+        if order_data["price"] is not None:
+            self._validate_decimal(order_data["price"], "price")
+        return self._parse_gateway_time(order_data)
+
+    def _validate_cancel_message(self, order_data: dict[str, Any]) -> None:
+        """Validate a cancellation message before handing it to the engine.
+
+        Args:
+            order_data: The decoded cancellation message.
+        """
+        self._validate_uuid(self._require_string(order_data, "order_id"), "order_id")
+        self._validate_uuid(self._require_string(order_data, "stock_id"), "stock_id")
+        self._require_string(order_data, "ticker")
+
     async def _process_message(self, message: ConsumerRecord) -> None:
         """
         Processes a single message from Kafka.
@@ -74,51 +203,60 @@ class OrderConsumer:
             message: The message received from Kafka.
         """
         order_id: str | None = None
+        message_type: str | None = None
+        order_data: dict[str, Any] = {}
+        gateway_time: datetime | None = None
         try:
             if message.value is None:
                 return
-            order_data = orjson.loads(message.value)
+            order_data = self._decode_message_payload(message.value)
 
-            match order_data.get("type"):
+            message_type = self._require_string(order_data, "type")
+            match message_type:
                 case "health_check":
                     return
                 case "cancel":
-                    order_id = order_data["order_id"]
-                    logger.info(f"Processing cancellation: {order_id=}")
-                    result = await self.matching_engine.cancel_order(order_data)
-                    logger.info(f"Cancelled order {order_id=}: {result}")
-                    return
+                    order_id = self._require_string(order_data, "order_id")
+                    self._validate_cancel_message(order_data)
                 case "order":
-                    order_id = order_data["id"]
-                    # Track the latency for new orders.
-                    gateway_time = datetime.fromisoformat(
-                        order_data["gateway_received_at"]
-                    )
-                    kafka_latency = (
-                        datetime.now(timezone.utc) - gateway_time
-                    ).total_seconds() * 1000
-                    logger.info(
-                        f"Processing order: {order_id=}, "
-                        f"kafka_latency={kafka_latency:.2f}ms"
-                    )
-
-                    start_process = datetime.now(timezone.utc)
-                    await self.matching_engine.process_order(order_data)
-                    process_time = (
-                        datetime.now(timezone.utc) - start_process
-                    ).total_seconds() * 1000
-                    total_latency = (
-                        datetime.now(timezone.utc) - gateway_time
-                    ).total_seconds() * 1000
-                    logger.info(
-                        f"Order processed: {order_id=}, "
-                        f"matching_time={process_time:.2f}ms, "
-                        f"total_latency={total_latency:.2f}ms"
-                    )
+                    order_id = self._require_string(order_data, "id")
+                    gateway_time = self._validate_order_message(order_data)
                 case _:
-                    raise ValueError(f"Unknown order type: {order_data.get('type')!r}")
-        except RECOVERABLE_ERRORS as e:
+                    raise ValueError(f"Unknown message type: {message_type!r}")
+        except MALFORMED_MESSAGE_ERRORS as e:
             self._log_skipped_message(message, e, order_id)
+            return
+
+        if message_type == "cancel":
+            logger.info(f"Processing cancellation: {order_id=}")
+            result = await self.matching_engine.cancel_order(order_data)
+            logger.info(f"Cancelled order {order_id=}: {result}")
+            return
+
+        if message_type == "order":
+            if gateway_time is None:
+                raise RuntimeError("Order message was parsed without gateway time.")
+            # Track the latency for new orders.
+            kafka_latency = (
+                datetime.now(timezone.utc) - gateway_time
+            ).total_seconds() * 1000
+            logger.info(
+                f"Processing order: {order_id=}, kafka_latency={kafka_latency:.2f}ms"
+            )
+
+            start_process = datetime.now(timezone.utc)
+            await self.matching_engine.process_order(order_data)
+            process_time = (
+                datetime.now(timezone.utc) - start_process
+            ).total_seconds() * 1000
+            total_latency = (
+                datetime.now(timezone.utc) - gateway_time
+            ).total_seconds() * 1000
+            logger.info(
+                f"Order processed: {order_id=}, "
+                f"matching_time={process_time:.2f}ms, "
+                f"total_latency={total_latency:.2f}ms"
+            )
 
     def _log_skipped_message(
         self,

--- a/tests/test_matching/test_order_consumer.py
+++ b/tests/test_matching/test_order_consumer.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import cast
+from typing import Any, ClassVar, cast
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -7,8 +7,43 @@ import orjson
 import pytest
 from aiokafka import ConsumerRecord
 
+from order_book_simulator.matching import order_consumer as order_consumer_module
 from order_book_simulator.matching.matching_engine import MatchingEngine
 from order_book_simulator.matching.order_consumer import OrderConsumer
+
+
+class FakeKafkaConsumer:
+    """Provide an async iterable Kafka consumer for start-loop tests."""
+
+    queued_messages: ClassVar[list[ConsumerRecord]] = []
+    last_instance: ClassVar["FakeKafkaConsumer | None"] = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.messages = list(self.__class__.queued_messages)
+        self.commit_count = 0
+        self.started = False
+        self.stopped = False
+        FakeKafkaConsumer.last_instance = self
+
+    async def start(self) -> None:
+        """Record that the fake consumer was started."""
+        self.started = True
+
+    async def stop(self) -> None:
+        """Record that the fake consumer was stopped."""
+        self.stopped = True
+
+    async def commit(self) -> None:
+        """Record an offset commit."""
+        self.commit_count += 1
+
+    def __aiter__(self) -> "FakeKafkaConsumer":
+        return self
+
+    async def __anext__(self) -> ConsumerRecord:
+        if not self.messages:
+            raise StopAsyncIteration
+        return self.messages.pop(0)
 
 
 def make_record(value: bytes | None, key: bytes | None = None) -> ConsumerRecord:
@@ -38,6 +73,23 @@ def engine() -> AsyncMock:
 def consumer(engine: AsyncMock) -> OrderConsumer:
     """Creates an OrderConsumer wired to the mocked matching engine."""
     return OrderConsumer(matching_engine=cast(MatchingEngine, engine))
+
+
+def valid_order_payload() -> bytes:
+    """Build a well-formed order payload for consumer tests."""
+    return orjson.dumps(
+        {
+            "type": "order",
+            "id": str(uuid4()),
+            "stock_id": str(uuid4()),
+            "ticker": "AAPL",
+            "side": "BUY",
+            "order_type": "LIMIT",
+            "price": "100",
+            "quantity": "10",
+            "gateway_received_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -122,13 +174,13 @@ async def test_unknown_order_type_is_skipped(
     engine: AsyncMock,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Tests that an unrecognised type is logged and skipped, not raised."""
+    """Tests that an unrecognised message type is logged and skipped."""
     caplog.set_level("ERROR")
     payload = orjson.dumps({"type": "definitely-not-real"})
 
     await consumer._process_message(make_record(payload))
 
-    assert "Unknown order type" in caplog.text
+    assert "Unknown message type" in caplog.text
     assert "ValueError" in caplog.text
     engine.process_order.assert_not_awaited()
 
@@ -177,6 +229,58 @@ async def test_unexpected_exception_propagates(
 
 
 @pytest.mark.asyncio
+async def test_matching_engine_value_error_propagates(
+    consumer: OrderConsumer,
+    engine: AsyncMock,
+):
+    """Test that engine ValueErrors are not treated as malformed messages."""
+    engine.process_order.side_effect = ValueError("engine invariant failed")
+
+    with pytest.raises(ValueError, match="engine invariant failed"):
+        await consumer._process_message(make_record(valid_order_payload()))
+
+
+@pytest.mark.asyncio
+async def test_matching_engine_type_error_propagates(
+    consumer: OrderConsumer,
+    engine: AsyncMock,
+):
+    """Test that engine TypeErrors are not treated as malformed messages."""
+    engine.process_order.side_effect = TypeError("engine type bug")
+
+    with pytest.raises(TypeError, match="engine type bug"):
+        await consumer._process_message(make_record(valid_order_payload()))
+
+
+@pytest.mark.asyncio
+async def test_invalid_order_schema_is_skipped_before_engine(
+    consumer: OrderConsumer,
+    engine: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test that malformed order fields are skipped before engine handoff."""
+    caplog.set_level("ERROR")
+    payload = orjson.dumps(
+        {
+            "type": "order",
+            "id": str(uuid4()),
+            "stock_id": "not-a-uuid",
+            "ticker": "AAPL",
+            "side": "BUY",
+            "order_type": "LIMIT",
+            "price": "100",
+            "quantity": "10",
+            "gateway_received_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    await consumer._process_message(make_record(payload))
+
+    assert "stock_id must be a UUID" in caplog.text
+    engine.process_order.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_truncates_oversized_payload_in_log(
     consumer: OrderConsumer, caplog: pytest.LogCaptureFixture
 ):
@@ -190,3 +294,50 @@ async def test_truncates_oversized_payload_in_log(
     # The truncated payload representation appears, not the full 2 KB.
     assert "payload='" in caplog.text
     assert "x" * 2049 not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_start_commits_after_skipping_malformed_message(
+    consumer: OrderConsumer,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test that deliberately skipped malformed messages still commit."""
+    FakeKafkaConsumer.queued_messages = [make_record(b"not valid json{{{")]
+    FakeKafkaConsumer.last_instance = None
+    monkeypatch.setattr(
+        order_consumer_module,
+        "AIOKafkaConsumer",
+        FakeKafkaConsumer,
+    )
+
+    await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert fake_consumer.commit_count == 1
+    assert fake_consumer.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_commit_when_engine_error_propagates(
+    consumer: OrderConsumer,
+    engine: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test that engine failures leave the Kafka offset uncommitted."""
+    engine.process_order.side_effect = ValueError("engine invariant failed")
+    FakeKafkaConsumer.queued_messages = [make_record(valid_order_payload())]
+    FakeKafkaConsumer.last_instance = None
+    monkeypatch.setattr(
+        order_consumer_module,
+        "AIOKafkaConsumer",
+        FakeKafkaConsumer,
+    )
+
+    with pytest.raises(ValueError, match="engine invariant failed"):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert fake_consumer.commit_count == 0
+    assert fake_consumer.stopped is True


### PR DESCRIPTION
# Summary
- Split Kafka message handling into parseable envelope validation and engine execution
  - Malformed payloads are still logged and skipped with context
  - Engine failures now escape the consumer loop so Kafka offsets are not committed
- Added explicit validation for consumer message shape before handoff to the matcher
- Added regression coverage for engine exception propagation and offset commit behaviour

## Rationale
- `ValueError` and `TypeError` can come from both bad Kafka bytes and real matcher bugs – catching them across the whole message handler made those two cases indistinguishable
- Offsets should advance only after a message is handled or intentionally skipped – otherwise an engine invariant failure can disappear as a logged malformed record
