### PR TITLE
fix: Preserve market-data offsets until DB flush succeeds

### DIFF
--- a/src/order_book_simulator/market_data/db_consumer.py
+++ b/src/order_book_simulator/market_data/db_consumer.py
@@ -1,10 +1,11 @@
 import asyncio
 import logging
 import time
+from typing import Any
 from uuid import UUID
 
 import orjson
-from aiokafka import AIOKafkaConsumer
+from aiokafka import AIOKafkaConsumer, ConsumerRecord, TopicPartition
 
 from order_book_simulator.database.connection import AsyncSessionLocal
 from order_book_simulator.market_data.persistence import (
@@ -13,6 +14,8 @@ from order_book_simulator.market_data.persistence import (
 )
 
 logger = logging.getLogger(__name__)
+
+MALFORMED_MESSAGE_ERRORS = (orjson.JSONDecodeError, TypeError)
 
 
 class MarketDataDBConsumer:
@@ -27,6 +30,8 @@ class MarketDataDBConsumer:
         group_id: str = "market-data",
         batch_size: int = 50,
         batch_timeout_ms: int = 100,
+        max_flush_retries: int = 3,
+        retry_backoff_ms: int = 100,
     ):
         """
         Creates a new market data DB consumer.
@@ -37,37 +42,117 @@ class MarketDataDBConsumer:
             group_id: Consumer group ID.
             batch_size: Number of entries to process in each batch.
             batch_timeout_ms: Timeout for batch processing in milliseconds.
+            max_flush_retries: Maximum attempts to persist a failed batch.
+            retry_backoff_ms: Delay between failed persistence attempts.
         """
         self.consumer: AIOKafkaConsumer | None = None
         self.bootstrap_servers: str = bootstrap_servers
         self.topic: str = topic
         self.group_id: str = group_id
-        self.batch: list[dict] = []
+        self.batch: list[dict[str, Any]] = []
+        self.pending_offsets: dict[TopicPartition, int] = {}
         self.batch_size: int = batch_size
         self.batch_timeout: float = batch_timeout_ms / 1000.0
+        self.max_flush_retries: int = max_flush_retries
+        self.retry_backoff: float = retry_backoff_ms / 1000.0
         self.last_flush: float = time.time()
 
     async def _flush_batch(self) -> None:
         if not self.batch:
             return
 
-        try:
-            async with AsyncSessionLocal() as session:
-                async with session.begin():
-                    for data in self.batch:
-                        stock_id = UUID(data["stock_id"])
-                        await persist_market_snapshot(stock_id, data, session)
-                        if data.get("trades"):
-                            await persist_trades(stock_id, data["trades"], session)
-            logger.debug(
-                f"Flushed batch of {len(self.batch)} market data entries to Postgres"
-            )
-        except Exception as exc:
-            logger.error(f"Error flushing batch: {exc}")
-            # TODO: Handle failed batch (dead letter queue, retry, etc.)
+        batch = list(self.batch)
+        offsets = dict(self.pending_offsets)
+        for attempt in range(1, self.max_flush_retries + 1):
+            try:
+                await self._persist_batch(batch)
+                break
+            except Exception as exc:
+                if attempt >= self.max_flush_retries:
+                    logger.exception(
+                        "Failed to flush market data batch after "
+                        f"{self.max_flush_retries} attempts"
+                    )
+                    raise
+                logger.warning(
+                    "Failed to flush market data batch "
+                    f"(attempt {attempt}/{self.max_flush_retries}): {exc}. "
+                    f"Retrying in {self.retry_backoff:.3f} seconds..."
+                )
+                await asyncio.sleep(self.retry_backoff)
 
+        await self._commit_offsets(offsets)
         self.batch.clear()
+        self.pending_offsets.clear()
         self.last_flush = time.time()
+        logger.debug(f"Flushed batch of {len(batch)} market data entries to Postgres")
+
+    async def _persist_batch(self, batch: list[dict[str, Any]]) -> None:
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                for data in batch:
+                    stock_id = UUID(data["stock_id"])
+                    await persist_market_snapshot(stock_id, data, session)
+                    if data.get("trades"):
+                        await persist_trades(stock_id, data["trades"], session)
+
+    async def _commit_offsets(self, offsets: dict[TopicPartition, int]) -> None:
+        if not offsets or self.consumer is None:
+            return
+
+        await self.consumer.commit(offsets)
+
+    async def _commit_message_offset(self, message: ConsumerRecord) -> None:
+        topic_partition = TopicPartition(message.topic, message.partition)
+        await self._commit_offsets({topic_partition: message.offset + 1})
+
+    def _add_to_batch(
+        self,
+        data: dict[str, Any],
+        message: ConsumerRecord,
+    ) -> None:
+        self.batch.append(data)
+        topic_partition = TopicPartition(message.topic, message.partition)
+        next_offset = message.offset + 1
+        self.pending_offsets[topic_partition] = max(
+            next_offset,
+            self.pending_offsets.get(topic_partition, 0),
+        )
+
+    def _should_flush(self) -> bool:
+        return bool(self.batch) and (
+            len(self.batch) >= self.batch_size
+            or time.time() - self.last_flush >= self.batch_timeout
+        )
+
+    def _decode_message(self, message: ConsumerRecord) -> dict[str, Any] | None:
+        if not message.value:
+            return None
+
+        data = orjson.loads(message.value)
+        if not isinstance(data, dict):
+            raise TypeError("Market data message payload must be a JSON object")
+        return data
+
+    def _log_skipped_message(
+        self,
+        message: ConsumerRecord,
+        error: Exception,
+    ) -> None:
+        payload_repr = (
+            message.value[:500].decode("utf-8", errors="replace")
+            if message.value
+            else None
+        )
+        logger.error(
+            "Skipping malformed market data Kafka message: "
+            f"error_type={type(error).__name__}, "
+            f"error={error!s}, "
+            f"topic={message.topic}, "
+            f"partition={message.partition}, "
+            f"offset={message.offset}, "
+            f"payload={payload_repr!r}"
+        )
 
     async def start(self) -> None:
         """
@@ -78,22 +163,36 @@ class MarketDataDBConsumer:
             self.topic,
             bootstrap_servers=self.bootstrap_servers,
             group_id=self.group_id,
+            enable_auto_commit=False,
         )
         await self.consumer.start()
         logger.info(f"Started consuming from {self.topic} on {self.bootstrap_servers}")
 
         try:
-            async for message in self.consumer:
-                data = orjson.loads(message.value) if message.value else None
-                if not data:
-                    continue
-                self.batch.append(data)
-
-                should_flush = (
-                    len(self.batch) >= self.batch_size
-                    or time.time() - self.last_flush >= self.batch_timeout
+            while True:
+                records = await self.consumer.getmany(
+                    timeout_ms=max(1, int(self.batch_timeout * 1000)),
+                    max_records=self.batch_size,
                 )
-                if should_flush:
+
+                for messages in records.values():
+                    for message in messages:
+                        try:
+                            data = self._decode_message(message)
+                        except MALFORMED_MESSAGE_ERRORS as exc:
+                            self._log_skipped_message(message, exc)
+                            await self._commit_message_offset(message)
+                            continue
+
+                        if data is None:
+                            await self._commit_message_offset(message)
+                            continue
+
+                        self._add_to_batch(data, message)
+                        if self._should_flush():
+                            await self._flush_batch()
+
+                if self._should_flush():
                     await self._flush_batch()
         finally:
             await self._flush_batch()

--- a/tests/test_market_data/test_db_consumer.py
+++ b/tests/test_market_data/test_db_consumer.py
@@ -1,16 +1,70 @@
+import asyncio
 import time
 from types import SimpleNamespace
+from typing import Any, ClassVar, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
+import orjson
 import pytest
+from aiokafka import AIOKafkaConsumer, ConsumerRecord, TopicPartition
 
 from order_book_simulator.market_data import db_consumer as db_consumer_module
 from order_book_simulator.market_data.db_consumer import MarketDataDBConsumer
 
 
-def create_market_data(stock_id: str | None = None) -> dict:
-    """Creates test market data."""
+class StopPolling(Exception):
+    """Stop a fake Kafka consumer loop in tests."""
+
+
+class FakeKafkaConsumer:
+    """Provide a controllable Kafka consumer for DB consumer tests."""
+
+    poll_results: ClassVar[list[Any]] = []
+    last_instance: ClassVar["FakeKafkaConsumer | None"] = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.commits: list[dict[TopicPartition, int]] = []
+        self.getmany_calls: list[dict[str, Any]] = []
+        self.started = False
+        self.stopped = False
+        FakeKafkaConsumer.last_instance = self
+
+    async def start(self) -> None:
+        """Record that the fake consumer was started."""
+        self.started = True
+
+    async def stop(self) -> None:
+        """Record that the fake consumer was stopped."""
+        self.stopped = True
+
+    async def commit(self, offsets: dict[TopicPartition, int] | None = None) -> None:
+        """Record committed offsets."""
+        if offsets is None:
+            offsets = {}
+        self.commits.append(offsets)
+
+    async def getmany(
+        self, **kwargs: Any
+    ) -> dict[TopicPartition, list[ConsumerRecord]]:
+        """Return configured poll results."""
+        self.getmany_calls.append(kwargs)
+        if not self.__class__.poll_results:
+            raise StopPolling
+
+        result = self.__class__.poll_results.pop(0)
+        if result == "sleep_empty":
+            await asyncio.sleep(0.02)
+            return {}
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+
+def create_market_data(stock_id: str | None = None) -> dict[str, Any]:
+    """Create test market data."""
     return {
         "stock_id": stock_id or str(uuid4()),
         "ticker": "TEST",
@@ -20,21 +74,57 @@ def create_market_data(stock_id: str | None = None) -> dict:
     }
 
 
+def make_record(
+    value: bytes | None,
+    offset: int = 42,
+    partition: int = 0,
+) -> ConsumerRecord:
+    """Build a minimal ConsumerRecord for tests."""
+    return ConsumerRecord(
+        topic="market-data",
+        partition=partition,
+        offset=offset,
+        timestamp=0,
+        timestamp_type=0,
+        key=None,
+        value=value,
+        checksum=None,
+        serialized_key_size=-1,
+        serialized_value_size=-1,
+        headers=(),
+    )
+
+
+def use_fake_kafka(
+    monkeypatch: pytest.MonkeyPatch,
+    poll_results: list[Any],
+) -> None:
+    """Patch the DB consumer to use a fake Kafka consumer."""
+    FakeKafkaConsumer.poll_results = poll_results
+    FakeKafkaConsumer.last_instance = None
+    monkeypatch.setattr(db_consumer_module, "AIOKafkaConsumer", FakeKafkaConsumer)
+
+
 @pytest.fixture
 def consumer() -> MarketDataDBConsumer:
-    """Creates a consumer with small batch size for testing."""
-    return MarketDataDBConsumer(batch_size=3, batch_timeout_ms=100)
+    """Create a consumer with small batch size for testing."""
+    return MarketDataDBConsumer(
+        batch_size=3,
+        batch_timeout_ms=100,
+        max_flush_retries=1,
+        retry_backoff_ms=0,
+    )
 
 
 @pytest.fixture
 def mock_db(monkeypatch):
-    """Patches database dependencies for flush_batch tests."""
+    """Patch database dependencies for flush_batch tests."""
     mock_session = AsyncMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=None)
     mock_session.begin = MagicMock(return_value=AsyncMock())
     mock_session.begin.return_value.__aenter__ = AsyncMock()
-    mock_session.begin.return_value.__aexit__ = AsyncMock()
+    mock_session.begin.return_value.__aexit__ = AsyncMock(return_value=None)
 
     mock_factory = MagicMock(return_value=mock_session)
     mock_persist_snapshot = AsyncMock()
@@ -105,10 +195,13 @@ async def test_flush_batch_persists_trades_when_present(consumer, mock_db):
 async def test_flush_batch_clears_batch(consumer, mock_db):
     """Flushing should clear the batch."""
     consumer.batch = [create_market_data(), create_market_data()]
+    topic_partition = TopicPartition("market-data", 0)
+    consumer.pending_offsets = {topic_partition: 43}
 
     await consumer._flush_batch()
 
     assert len(consumer.batch) == 0
+    assert consumer.pending_offsets == {}
 
 
 @pytest.mark.asyncio
@@ -126,15 +219,68 @@ async def test_flush_batch_updates_last_flush_time(consumer, mock_db):
 
 
 @pytest.mark.asyncio
-async def test_flush_batch_handles_errors_gracefully(consumer, mock_db):
-    """Flushing should handle errors without raising."""
+async def test_flush_batch_raises_and_retains_batch_on_db_error(consumer, mock_db):
+    """Flushing should keep uncommitted batches when persistence fails."""
+    fake_consumer = SimpleNamespace(commit=AsyncMock())
+    consumer.consumer = cast(AIOKafkaConsumer, fake_consumer)
     consumer.batch = [create_market_data()]
+    topic_partition = TopicPartition("market-data", 0)
+    consumer.pending_offsets = {topic_partition: 43}
     mock_db.persist_snapshot.side_effect = Exception("DB error")
 
-    # Should not raise.
+    with pytest.raises(Exception, match="DB error"):
+        await consumer._flush_batch()
+
+    assert len(consumer.batch) == 1
+    assert consumer.pending_offsets == {topic_partition: 43}
+    fake_consumer.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_flush_batch_retries_before_success(mock_db):
+    """Flushing should retry transient database errors before giving up."""
+    consumer = MarketDataDBConsumer(
+        batch_size=3,
+        batch_timeout_ms=100,
+        max_flush_retries=2,
+        retry_backoff_ms=0,
+    )
+    consumer.batch = [create_market_data()]
+    mock_db.persist_snapshot.side_effect = [Exception("transient"), None]
+
     await consumer._flush_batch()
-    # Batch should still be cleared.
+
+    assert mock_db.persist_snapshot.call_count == 2
     assert len(consumer.batch) == 0
+
+
+@pytest.mark.asyncio
+async def test_flush_batch_commits_offsets_after_success(consumer, mock_db):
+    """Flushing should commit Kafka offsets after successful persistence."""
+    fake_consumer = SimpleNamespace(commit=AsyncMock())
+    consumer.consumer = cast(AIOKafkaConsumer, fake_consumer)
+    consumer.batch = [create_market_data()]
+    topic_partition = TopicPartition("market-data", 0)
+    consumer.pending_offsets = {topic_partition: 43}
+
+    await consumer._flush_batch()
+
+    fake_consumer.commit.assert_awaited_once_with({topic_partition: 43})
+
+
+@pytest.mark.asyncio
+async def test_flush_batch_does_not_commit_offsets_on_db_error(consumer, mock_db):
+    """Flushing should not commit Kafka offsets when persistence fails."""
+    fake_consumer = SimpleNamespace(commit=AsyncMock())
+    consumer.consumer = cast(AIOKafkaConsumer, fake_consumer)
+    consumer.batch = [create_market_data()]
+    consumer.pending_offsets = {TopicPartition("market-data", 0): 43}
+    mock_db.persist_snapshot.side_effect = Exception("DB error")
+
+    with pytest.raises(Exception, match="DB error"):
+        await consumer._flush_batch()
+
+    fake_consumer.commit.assert_not_awaited()
 
 
 def test_batch_size_threshold(consumer):
@@ -142,14 +288,10 @@ def test_batch_size_threshold(consumer):
     consumer.batch = [create_market_data() for _ in range(2)]
     consumer.last_flush = time.time()
 
-    # Below threshold.
-    should_flush = len(consumer.batch) >= consumer.batch_size
-    assert not should_flush
+    assert not consumer._should_flush()
 
-    # At threshold.
     consumer.batch.append(create_market_data())
-    should_flush = len(consumer.batch) >= consumer.batch_size
-    assert should_flush
+    assert consumer._should_flush()
 
 
 def test_batch_timeout_threshold(consumer):
@@ -157,11 +299,118 @@ def test_batch_timeout_threshold(consumer):
     consumer.batch = [create_market_data()]
     consumer.last_flush = time.time()
 
-    # Just flushed, no timeout.
-    should_flush = time.time() - consumer.last_flush >= consumer.batch_timeout
-    assert not should_flush
+    assert not consumer._should_flush()
 
-    # Simulate timeout.
     consumer.last_flush = time.time() - consumer.batch_timeout - 0.01
-    should_flush = time.time() - consumer.last_flush >= consumer.batch_timeout
-    assert should_flush
+    assert consumer._should_flush()
+
+
+def test_add_to_batch_tracks_highest_offsets(consumer):
+    """Consumer should track the highest pending offset for each partition."""
+    consumer._add_to_batch(create_market_data(), make_record(b"{}", offset=3))
+    consumer._add_to_batch(create_market_data(), make_record(b"{}", offset=7))
+
+    assert consumer.pending_offsets == {TopicPartition("market-data", 0): 8}
+
+
+@pytest.mark.asyncio
+async def test_start_disables_auto_commit(
+    consumer,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Consumer should disable Kafka auto-commit."""
+    use_fake_kafka(monkeypatch, [StopPolling()])
+
+    with pytest.raises(StopPolling):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert fake_consumer.kwargs["enable_auto_commit"] is False
+    assert fake_consumer.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_start_flushes_partial_batch_after_timeout(
+    mock_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Consumer should flush partial batches even when the topic goes quiet."""
+    consumer = MarketDataDBConsumer(
+        batch_size=3,
+        batch_timeout_ms=10,
+        max_flush_retries=1,
+        retry_backoff_ms=0,
+    )
+    topic_partition = TopicPartition("market-data", 0)
+    payload = orjson.dumps(create_market_data())
+    use_fake_kafka(
+        monkeypatch,
+        [
+            {topic_partition: [make_record(payload, offset=0)]},
+            "sleep_empty",
+            StopPolling(),
+        ],
+    )
+
+    with pytest.raises(StopPolling):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert mock_db.persist_snapshot.call_count == 1
+    assert fake_consumer.commits == [{topic_partition: 1}]
+    assert consumer.batch == []
+
+
+@pytest.mark.asyncio
+async def test_start_commits_empty_messages_without_persisting(
+    mock_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Consumer should commit empty Kafka records without adding them to a batch."""
+    consumer = MarketDataDBConsumer(max_flush_retries=1, retry_backoff_ms=0)
+    topic_partition = TopicPartition("market-data", 0)
+    use_fake_kafka(
+        monkeypatch,
+        [
+            {topic_partition: [make_record(None, offset=5)]},
+            StopPolling(),
+        ],
+    )
+
+    with pytest.raises(StopPolling):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert fake_consumer.commits == [{topic_partition: 6}]
+    mock_db.persist_snapshot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_commits_malformed_messages_without_persisting(
+    mock_db,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Consumer should skip and commit malformed Kafka records."""
+    caplog.set_level("ERROR")
+    consumer = MarketDataDBConsumer(max_flush_retries=1, retry_backoff_ms=0)
+    topic_partition = TopicPartition("market-data", 0)
+    use_fake_kafka(
+        monkeypatch,
+        [
+            {topic_partition: [make_record(b"not json", offset=8)]},
+            StopPolling(),
+        ],
+    )
+
+    with pytest.raises(StopPolling):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert fake_consumer.commits == [{topic_partition: 9}]
+    assert "Skipping malformed market data Kafka message" in caplog.text
+    mock_db.persist_snapshot.assert_not_called()


### PR DESCRIPTION
# Summary
- Reworked market-data DB ingestion so Kafka offsets advanced only after successful persistence
  - Retained pending payloads and offsets when a database flush failed
  - Retried failed flushes before letting the consumer stop with offsets uncommitted
- Switched the consumer loop to bounded polling so partial batches flushed when the topic went quiet
- Added explicit handling for empty and malformed market-data records so poison payloads were skipped without touching the database
- Expanded DB consumer coverage around retry behaviour, offset ordering, timeout flushing, and malformed-record handling

## Rationale
- Auto-commit and lossy batch clearing made DB outages indistinguishable from successful ingestion
  - Kafka could advance while PostgreSQL never received the batch, which broke replay guarantees after a restart
- Quiet topics needed a real timer-driven poll loop
  - Checking the timeout only after the next message meant partial batches could sit in memory indefinitely
