### PR TITLE
fix: Persist market snapshots with typed PostgreSQL JSONB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,22 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_DB: orderbook_test
+          POSTGRES_USER: orderbook_user
+          POSTGRES_PASSWORD: orderbook_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U orderbook_user -d orderbook_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      TEST_DATABASE_URL: postgresql+asyncpg://orderbook_user:orderbook_password@localhost:5432/orderbook_test
     strategy:
       matrix:
         python-version:

--- a/src/order_book_simulator/market_data/persistence.py
+++ b/src/order_book_simulator/market_data/persistence.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
 
-import orjson
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -22,15 +22,18 @@ async def persist_market_snapshot(
     query = text("""
         INSERT INTO market_snapshot (stock_id, timestamp, bids, asks)
         VALUES (:stock_id, :timestamp, :bids, :asks)
-    """)
+    """).bindparams(
+        bindparam("bids", type_=JSONB),
+        bindparam("asks", type_=JSONB),
+    )
 
     await db.execute(
         query,
         {
             "stock_id": stock_id,
-            "timestamp": datetime.now(),
-            "bids": orjson.dumps(snapshot["bids"]),
-            "asks": orjson.dumps(snapshot["asks"]),
+            "timestamp": datetime.now(timezone.utc),
+            "bids": snapshot["bids"],
+            "asks": snapshot["asks"],
         },
     )
 

--- a/tests/integration/test_market_data_persistence.py
+++ b/tests/integration/test_market_data_persistence.py
@@ -1,0 +1,151 @@
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import uuid4
+
+import asyncpg
+import orjson
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from order_book_simulator.market_data import db_consumer as db_consumer_module
+from order_book_simulator.market_data.db_consumer import MarketDataDBConsumer
+
+SCHEMA_PATH = (
+    Path(__file__).parents[2]
+    / "src"
+    / "order_book_simulator"
+    / "database"
+    / "schema.sql"
+)
+TEST_DATABASE_URL_ENV = "TEST_DATABASE_URL"
+
+
+def _asyncpg_dsn(database_url: str) -> str:
+    return database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+@pytest_asyncio.fixture
+async def postgres_session_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Create an isolated PostgreSQL schema using the production DDL."""
+    database_url = os.getenv(TEST_DATABASE_URL_ENV)
+    if database_url is None:
+        pytest.skip(f"{TEST_DATABASE_URL_ENV} is not configured")
+
+    schema = f"test_{uuid4().hex}"
+    connection = await asyncpg.connect(_asyncpg_dsn(database_url))
+    engine = None
+
+    try:
+        await connection.execute(f'CREATE SCHEMA "{schema}"')
+        await connection.execute(f'SET search_path TO "{schema}", public')
+        await connection.execute(SCHEMA_PATH.read_text())
+
+        engine = create_async_engine(
+            database_url,
+            connect_args={"server_settings": {"search_path": f'"{schema}", public'}},
+        )
+        session_factory = async_sessionmaker(
+            engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+        monkeypatch.setattr(
+            db_consumer_module,
+            "AsyncSessionLocal",
+            session_factory,
+        )
+        yield session_factory
+    finally:
+        if engine is not None:
+            await engine.dispose()
+        await connection.execute(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE')
+        await connection.close()
+
+
+@pytest.mark.asyncio
+async def test_persist_batch_stores_jsonb_snapshot_and_trade(
+    postgres_session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Persist a complete market-data batch against the production schema."""
+    stock_id = uuid4()
+    buyer_order_id = uuid4()
+    seller_order_id = uuid4()
+    snapshot = orjson.loads(
+        orjson.dumps(
+            {
+                "stock_id": str(stock_id),
+                "ticker": "TEST",
+                "bids": [{"price": "100.00", "quantity": "10", "order_count": 1}],
+                "asks": [{"price": "101.00", "quantity": "5", "order_count": 1}],
+                "trades": [
+                    {
+                        "price": "100.50",
+                        "quantity": "5",
+                        "buyer_order_id": str(buyer_order_id),
+                        "seller_order_id": str(seller_order_id),
+                        "timestamp": "2026-07-26T12:00:00+00:00",
+                    }
+                ],
+            }
+        )
+    )
+
+    async with postgres_session_factory() as session:
+        async with session.begin():
+            await session.execute(
+                text("""
+                    INSERT INTO stock (
+                        id, ticker, company_name, min_order_size,
+                        max_order_size, price_precision
+                    )
+                    VALUES (
+                        :id, :ticker, :company_name, :min_order_size,
+                        :max_order_size, :price_precision
+                    )
+                """),
+                {
+                    "id": stock_id,
+                    "ticker": "TEST",
+                    "company_name": "Test Company",
+                    "min_order_size": 1,
+                    "max_order_size": 1000,
+                    "price_precision": 2,
+                },
+            )
+
+    consumer = MarketDataDBConsumer()
+    await consumer._persist_batch([snapshot])
+
+    async with postgres_session_factory() as session:
+        snapshot_result = await session.execute(
+            text("""
+                    SELECT bids, asks
+                    FROM market_snapshot
+                    WHERE stock_id = :stock_id
+                """),
+            {"stock_id": stock_id},
+        )
+        snapshot_row = snapshot_result.mappings().one()
+        trade_count = (
+            await session.execute(
+                text("""
+                    SELECT COUNT(*)
+                    FROM trade
+                    WHERE stock_id = :stock_id
+                """),
+                {"stock_id": stock_id},
+            )
+        ).scalar_one()
+
+    assert snapshot_row["bids"] == snapshot["bids"]
+    assert snapshot_row["asks"] == snapshot["asks"]
+    assert trade_count == 1


### PR DESCRIPTION
# Summary
- Replaced pre-serialised snapshot bytes with typed `JSONB` bindings so market-data batches could commit through `asyncpg`
- Added PostgreSQL integration coverage that applied the production schema and persisted a wire-shaped snapshot and trade atomically
- Added PostgreSQL to the test workflow so the production persistence path ran without mocked database writes

## Rationale
- Existing tests mocked persistence and remained green while every non-empty production batch rolled back before its trades could be written