### PR TITLE
fix: Prevent skipped market-data records from advancing offsets early

### DIFF
--- a/src/order_book_simulator/market_data/db_consumer.py
+++ b/src/order_book_simulator/market_data/db_consumer.py
@@ -105,18 +105,30 @@ class MarketDataDBConsumer:
         topic_partition = TopicPartition(message.topic, message.partition)
         await self._commit_offsets({topic_partition: message.offset + 1})
 
-    def _add_to_batch(
-        self,
-        data: dict[str, Any],
-        message: ConsumerRecord,
-    ) -> None:
-        self.batch.append(data)
+    async def _acknowledge_skipped_message(self, message: ConsumerRecord) -> None:
+        """Acknowledge a skipped record without committing past buffered data."""
+        topic_partition = TopicPartition(message.topic, message.partition)
+        if topic_partition in self.pending_offsets:
+            self._track_pending_offset(message)
+            return
+
+        await self._commit_message_offset(message)
+
+    def _track_pending_offset(self, message: ConsumerRecord) -> None:
         topic_partition = TopicPartition(message.topic, message.partition)
         next_offset = message.offset + 1
         self.pending_offsets[topic_partition] = max(
             next_offset,
             self.pending_offsets.get(topic_partition, 0),
         )
+
+    def _add_to_batch(
+        self,
+        data: dict[str, Any],
+        message: ConsumerRecord,
+    ) -> None:
+        self.batch.append(data)
+        self._track_pending_offset(message)
 
     def _should_flush(self) -> bool:
         return bool(self.batch) and (
@@ -180,11 +192,11 @@ class MarketDataDBConsumer:
                             data = self._decode_message(message)
                         except MALFORMED_MESSAGE_ERRORS as exc:
                             self._log_skipped_message(message, exc)
-                            await self._commit_message_offset(message)
+                            await self._acknowledge_skipped_message(message)
                             continue
 
                         if data is None:
-                            await self._commit_message_offset(message)
+                            await self._acknowledge_skipped_message(message)
                             continue
 
                         self._add_to_batch(data, message)

--- a/tests/test_market_data/test_db_consumer.py
+++ b/tests/test_market_data/test_db_consumer.py
@@ -414,3 +414,82 @@ async def test_start_commits_malformed_messages_without_persisting(
     assert fake_consumer.commits == [{topic_partition: 9}]
     assert "Skipping malformed market data Kafka message" in caplog.text
     mock_db.persist_snapshot.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "skipped_value",
+    [None, b"not json"],
+    ids=["empty", "malformed"],
+)
+@pytest.mark.asyncio
+async def test_start_defers_skipped_offset_until_buffered_record_is_persisted(
+    skipped_value: bytes | None,
+    mock_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Commit a skipped record only after earlier buffered data is durable."""
+    consumer = MarketDataDBConsumer(
+        batch_size=50,
+        batch_timeout_ms=60_000,
+        max_flush_retries=1,
+        retry_backoff_ms=0,
+    )
+    topic_partition = TopicPartition("market-data", 0)
+    valid_payload = orjson.dumps(create_market_data())
+    use_fake_kafka(
+        monkeypatch,
+        [
+            {
+                topic_partition: [
+                    make_record(valid_payload, offset=5),
+                    make_record(skipped_value, offset=6),
+                ]
+            },
+            StopPolling(),
+        ],
+    )
+
+    with pytest.raises(StopPolling):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    mock_db.persist_snapshot.assert_awaited_once()
+    assert fake_consumer.commits == [{topic_partition: 7}]
+
+
+@pytest.mark.asyncio
+async def test_start_retains_skipped_offset_when_earlier_persistence_fails(
+    mock_db,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Leave skipped and buffered records uncommitted after a database failure."""
+    consumer = MarketDataDBConsumer(
+        batch_size=50,
+        batch_timeout_ms=60_000,
+        max_flush_retries=1,
+        retry_backoff_ms=0,
+    )
+    topic_partition = TopicPartition("market-data", 0)
+    valid_payload = orjson.dumps(create_market_data())
+    mock_db.persist_snapshot.side_effect = RuntimeError("database unavailable")
+    use_fake_kafka(
+        monkeypatch,
+        [
+            {
+                topic_partition: [
+                    make_record(valid_payload, offset=5),
+                    make_record(b"not json", offset=6),
+                ]
+            },
+            StopPolling(),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await consumer.start()
+
+    fake_consumer = FakeKafkaConsumer.last_instance
+    assert fake_consumer is not None
+    assert fake_consumer.commits == []
+    assert consumer.pending_offsets == {topic_partition: 7}


### PR DESCRIPTION
# Summary
- Prevented malformed and empty market-data records from committing beyond earlier valid records that were still awaiting persistence
- Folded skipped offsets into the existing per-partition pending frontier so the database batch becomes durable before its cumulative Kafka offset advances
- Preserved immediate acknowledgement for partitions without buffered data
- Added regression coverage for successful persistence and database failure at the skipped-record boundary

## Rationale
- Kafka commit offsets are cumulative – immediately acknowledging a skipped record could permanently lose an earlier valid record after a crash
- Reusing the existing pending frontier preserves per-partition ordering without introducing a separate acknowledgement subsystem