### PR TITLE
chore: Migrate type checking from Ty to Pyrefly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,6 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
-      - name: Run Pyrefly
-        run: uv run pyrefly check
-
       - name: Run tests with Pytest
         run: uv run coverage run --source=src/order_book_simulator/ -m pytest -v
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      - name: Run Pyrefly
+        run: uv run pyrefly check
+
       - name: Run tests with Pytest
         run: uv run coverage run --source=src/order_book_simulator/ -m pytest -v
 

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,0 +1,33 @@
+name: Type Check
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.14.x"
+
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@main
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@main
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run Pyrefly
+        run: uv run pyrefly check

--- a/benchmarks/unit/delta_payload_benchmark.py
+++ b/benchmarks/unit/delta_payload_benchmark.py
@@ -116,6 +116,8 @@ def run_benchmark() -> None:
     print(f"Total operations:        {num_operations:,}")
     print(f"Snapshot total bytes:     {total_snapshot_bytes:,}")
     print(f"Delta total bytes:        {total_delta_bytes:,}")
+    if total_snapshot_bytes == 0 or num_operations == 0:
+        raise RuntimeError("Benchmark did not record any operations")
     reduction = (1 - total_delta_bytes / total_snapshot_bytes) * 100
     print(f"Bandwidth reduction:      {reduction:.1f}%")
     print(

--- a/benchmarks/unit/multicast_benchmark.py
+++ b/benchmarks/unit/multicast_benchmark.py
@@ -20,7 +20,7 @@ import time
 from dataclasses import asdict
 from datetime import UTC, datetime
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import orjson
@@ -46,11 +46,8 @@ def _create_mock_publisher() -> MulticastPublisher:
     """Create a MulticastPublisher with a mocked UDP socket."""
     mock_socket_module = MagicMock()
     mock_socket_module.socket.return_value = MagicMock()
-    original = pub_module.socket
-    pub_module.socket = mock_socket_module  # type: ignore[assignment]
-    publisher = MulticastPublisher(group="239.1.1.1", port=5555)
-    pub_module.socket = original
-    return publisher
+    with patch.object(pub_module, "socket", mock_socket_module):
+        return MulticastPublisher(group="239.1.1.1", port=5555)
 
 
 def _create_delta_payload() -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,14 @@ dev = [
     "aiosqlite>=0.21.0",
     "coverage>=7.6.10",
     "httpx>=0.28.1",
+    "pandas-stubs>=3.0.5.260730",
+    "pyrefly>=1.2.0",
     "pytest>=9.0.3",
     "pytest-asyncio>=0.25.3",
     "pytest-cov>=6.0.0",
     "ruff==0.16.0",
     "sortedcontainers-stubs>=2.4.3",
-    "ty>=0.0.11",
+    "types-requests>=2.33.0.20260712",
     "typing-extensions>=4.12.2",
 ]
 
@@ -61,5 +63,12 @@ bump_pattern = "^(feat|fix|refactor|perf|build|ci|docs|style|test|chore|BREAKING
 [tool.hatch.build.targets.wheel]
 packages = ["src/order_book_simulator"]
 
-[tool.ty.environment]
-extra-paths = ["benchmarks/unit"]
+[tool.pyrefly]
+project-includes = [
+    "src/**/*.py",
+    "tests/**/*.py",
+    "benchmarks/**/*.py",
+    "examples/**/*.py",
+]
+python-version = "3.14"
+search-path = ["src", ".", "benchmarks/unit"]

--- a/src/order_book_simulator/common/cache.py
+++ b/src/order_book_simulator/common/cache.py
@@ -139,7 +139,8 @@ class OrderBookCache:
             The trade history for the stock.
         """
         key = self._get_trades_key(stock_id)
-        raw_data = await self.redis.lrange(key, -limit, -1)  # type: ignore[arg-type]
+        # redis-py types async commands as sync-or-async return unions.
+        raw_data = await self.redis.lrange(key, -limit, -1)  # pyrefly: ignore[not-async]
         return [orjson.loads(data) for data in reversed(raw_data)]
 
     async def append_trades(self, stock_id: UUID, trades: list[dict]) -> None:
@@ -155,9 +156,9 @@ class OrderBookCache:
         """
         key = self._get_trades_key(stock_id)
         serialised_trades = [orjson.dumps(trade, default=str) for trade in trades]
-        await self.redis.rpush(key, *serialised_trades)  # type: ignore[arg-type]
+        await self.redis.rpush(key, *serialised_trades)  # pyrefly: ignore[not-async]
         # Enforce the maximum trade history.
-        await self.redis.ltrim(key, -self.max_trade_history, -1)  # type: ignore[arg-type]
+        await self.redis.ltrim(key, -self.max_trade_history, -1)  # pyrefly: ignore[not-async]
 
     async def store_deltas(self, stock_id: UUID, deltas: list[Delta]) -> None:
         """
@@ -177,8 +178,8 @@ class OrderBookCache:
         ]
         # Store the deltas in Redis.
         deltas_key = self._get_deltas_key(stock_id)
-        await self.redis.rpush(deltas_key, *serialised_deltas)  # type: ignore[arg-type]
-        await self.redis.ltrim(deltas_key, -MAX_DELTA_HISTORY, -1)  # type: ignore[arg-type]
+        await self.redis.rpush(deltas_key, *serialised_deltas)  # pyrefly: ignore[not-async]
+        await self.redis.ltrim(deltas_key, -MAX_DELTA_HISTORY, -1)  # pyrefly: ignore[not-async]
         last_delta_seq_number = self._get_delta_seq_key(stock_id)
         await self.redis.set(last_delta_seq_number, deltas[-1].sequence_number)
 
@@ -210,7 +211,9 @@ class OrderBookCache:
             needs a full snapshot.
         """
         deltas_key = self._get_deltas_key(stock_id)
-        all_deltas: list[bytes] = await self.redis.lrange(deltas_key, 0, -1)  # type: ignore[arg-type]
+        all_deltas: list[bytes] = await self.redis.lrange(  # pyrefly: ignore[not-async]
+            deltas_key, 0, -1
+        )
         if not all_deltas:
             return []
 

--- a/src/order_book_simulator/gateway/ws_manager.py
+++ b/src/order_book_simulator/gateway/ws_manager.py
@@ -159,11 +159,19 @@ async def redis_pubsub_delta_subscriber(redis_url: str) -> None:
             if message is None:
                 continue
 
+            if message["type"] != "pmessage":
+                continue
+
             channel = message["channel"]
+            payload = message["data"]
+            if not isinstance(channel, (str, bytes)) or not isinstance(
+                payload, (str, bytes, bytearray, memoryview)
+            ):
+                continue
             if isinstance(channel, bytes):
                 channel = channel.decode()
             ticker = channel.split(":")[-1]
-            deltas = orjson.loads(message["data"])
+            deltas = orjson.loads(payload)
             ws_manager.broadcast({"type": "deltas", "data": deltas}, ticker)
     finally:
         await pubsub.punsubscribe("ws:deltas:*")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -277,15 +278,17 @@ def order_book() -> OrderBook:
 @pytest.fixture(autouse=True)
 def mock_redis():
     """Creates a mock Redis instance for testing."""
-    mock_data = {}
+    RedisScalar = str | bytes | int
+    mock_data: dict[str, RedisScalar | list[RedisScalar]] = {}
     streams: dict[str, list[tuple[str, dict]]] = {}
 
     class MockRedis:
-        async def set(self, key: str, value: str) -> None:
+        async def set(self, key: str, value: RedisScalar) -> None:
             mock_data[key] = value
 
-        async def get(self, key: str) -> str | None:
-            return mock_data.get(key)
+        async def get(self, key: str) -> RedisScalar | None:
+            value = mock_data.get(key)
+            return value if not isinstance(value, list) else None
 
         async def keys(self, pattern: str) -> list[str]:
             if pattern == "order_book:*":
@@ -298,7 +301,7 @@ def mock_redis():
         def exists(self, key: str) -> bool:
             return key in mock_data
 
-        async def lrange(self, key: str, start: int, end: int) -> list[str]:
+        async def lrange(self, key: str, start: int, end: int) -> list[RedisScalar]:
             data = mock_data.get(key, [])
             if not isinstance(data, list):
                 return []
@@ -307,18 +310,18 @@ def mock_redis():
                 return data[start:]
             return data[start : end + 1]
 
-        async def rpush(self, key: str, *values: str) -> int:
-            if key not in mock_data:
-                mock_data[key] = []
-            mock_data[key].extend(values)
-            return len(mock_data[key])
+        async def rpush(self, key: str, *values: RedisScalar) -> int:
+            data = cast(list[RedisScalar], mock_data.setdefault(key, []))
+            data.extend(values)
+            return len(data)
 
         async def ltrim(self, key: str, start: int, end: int) -> None:
-            if key in mock_data and isinstance(mock_data[key], list):
+            data = mock_data.get(key)
+            if isinstance(data, list):
                 if end == -1:
-                    mock_data[key] = mock_data[key][start:]
+                    mock_data[key] = data[start:]
                 else:
-                    mock_data[key] = mock_data[key][start : end + 1]
+                    mock_data[key] = data[start : end + 1]
 
         async def publish(self, channel: str, message: bytes) -> None:
             pass
@@ -359,7 +362,9 @@ def mock_redis():
             ]
             return [] if not entries else [(key, entries[: count or len(entries)])]
 
-    order_book_cache.redis = MockRedis()  # type: ignore[assignment]
+    # The concrete redis-py type is not structural, but this test double
+    # implements the subset exercised by the cache tests.
+    order_book_cache.redis = MockRedis()  # pyrefly: ignore[bad-argument-type]
     yield
     mock_data.clear()
 

--- a/uv.lock
+++ b/uv.lock
@@ -695,12 +695,14 @@ dev = [
     { name = "aiosqlite" },
     { name = "coverage" },
     { name = "httpx" },
+    { name = "pandas-stubs" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sortedcontainers-stubs" },
-    { name = "ty" },
+    { name = "types-requests" },
     { name = "typing-extensions" },
 ]
 
@@ -727,12 +729,14 @@ dev = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "coverage", specifier = ">=7.6.10" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pandas-stubs", specifier = ">=3.0.5.260730" },
+    { name = "pyrefly", specifier = ">=1.2.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.25.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = "==0.16.0" },
     { name = "sortedcontainers-stubs", specifier = ">=2.4.3" },
-    { name = "ty", specifier = ">=0.0.11" },
+    { name = "types-requests", specifier = ">=2.33.0.20260712" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 
@@ -795,6 +799,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
     { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
     { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.5.260730"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/d2/dea4a3a56b7b5f69c5fbca9f14625fcf28e1a39a657e9833d4a10bcac593/pandas_stubs-3.0.5.260730.tar.gz", hash = "sha256:f70a232c57d93a5a2c81f8a53953e10891a5374bc92652277deb325e2e4d0ff3", size = 114631, upload-time = "2026-07-30T14:31:42.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/c2/959caec5c46f484b5f8bb6def4b0cf7a45ba6acda26f12b75142d98cc5ae/pandas_stubs-3.0.5.260730-py3-none-any.whl", hash = "sha256:60e90e3e1eda6937e337e243cbe6217e151c11137cd7eddf832af537c7310bfd", size = 174807, upload-time = "2026-07-30T14:31:41.17Z" },
 ]
 
 [[package]]
@@ -1040,6 +1056,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/01/a86e9f24722b095c3f88e3616132b75a21b0df53804bdc6a45314dd4d93c/pyrefly-1.2.0.tar.gz", hash = "sha256:5485f960fc2481617068c918335c39ab1507ef90b6b5bd35bf57726e60e73185", size = 6243654, upload-time = "2026-08-01T02:56:27.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/9d/3c0ef1d4843987b22f996ed381ec9cf5a3b1273e29804db276252e4c95eb/pyrefly-1.2.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7f46d983ac49ddd2b043694960a01dc6a19a5cfd8eec609d6bd9c42866f91b4e", size = 14026305, upload-time = "2026-08-01T02:56:02.611Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/06/03bbb78fbea54cdc65b626619f3597d5611aca4fdef11e72a4e8360e7e63/pyrefly-1.2.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:756f669b5555090f5c1a4fef30db1785fabe657764f7e4e6dc88994dfb8ca82d", size = 13463880, upload-time = "2026-08-01T02:56:04.93Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/7d8bc00a38e93bbc9c3e7bd14d305f7948717e667c9bcddeab9dd42fd255/pyrefly-1.2.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3465812ce5ef4781fb592edbf2724547296f0a3124be115d73c7e8b2401862d", size = 13907329, upload-time = "2026-08-01T02:56:07.104Z" },
+    { url = "https://files.pythonhosted.org/packages/be/94/9e08b4bf799d0b8f36b55a2783c7ba5f51730cf0632a85a67b5b5ed876cd/pyrefly-1.2.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5de7b2ad2bba5c8055181681a84b74143eac2234a48ba5d1b7ed7e7a722b02bd", size = 15039020, upload-time = "2026-08-01T02:56:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/bd/bca5fd0c80f4daf8ee6903a29df9f3de1feb05ff0946b8f35ec8c5096b13/pyrefly-1.2.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:25822ea9505f589ea8a725e4268b475132fb89e038fbf092e446510443ac142a", size = 14986199, upload-time = "2026-08-01T02:56:11.924Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f7/f07087f3d185ad2eced0c56cef89ca5474dfb4ff25f146cd50a861c97553/pyrefly-1.2.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90efe75e17491ef5d636e10469e9278d7d0256b3b4c5e1f4750069bf3ae0f5d1", size = 14393715, upload-time = "2026-08-01T02:56:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/70/0d142c320e284b9e3ce35e9b1e58b8ce2ee1f578f2a7234bc30e5022b94f/pyrefly-1.2.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:368aaf7eee4f511ddc0f8e564cf14e01ab2f10b0db9105c6d5b153bf498d07bf", size = 13933008, upload-time = "2026-08-01T02:56:16.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e8/e84f11b6e1f63fd453ad3654213b9a0f6f4de8cef6b58038eef2d0d5955d/pyrefly-1.2.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d52d5da7bc65fb7675fbaa80eda879d4f8787c494f04cac21603330d3abbdbbe", size = 14431827, upload-time = "2026-08-01T02:56:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/810d31380f66c75e1c0779a408d3b16117b1b368b57894f6aa66bef21686/pyrefly-1.2.0-py3-none-win32.whl", hash = "sha256:8c90751de8506d938e8f802659c74cf35bd7a0036510ee6c634a38eebb280bfa", size = 13229447, upload-time = "2026-08-01T02:56:20.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/98/4dafa3c7a1caed2dc8cc708dde09ba27963c7736508f55b626fff3024113/pyrefly-1.2.0-py3-none-win_amd64.whl", hash = "sha256:8a8964c224ccc4882730130955815de21ff443c1ac3f0b90685b19bf63848170", size = 14087387, upload-time = "2026-08-01T02:56:23.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1c/df3cb0a2e5591660ded7a1836cd2f29dc48c91adb1c0a3a700a96f6d09e1/pyrefly-1.2.0-py3-none-win_arm64.whl", hash = "sha256:3a90bb8df39dfbac74b1f3b2e9d7c526b8f80568884c3944d955023a73ebf61e", size = 13430873, upload-time = "2026-08-01T02:56:25.425Z" },
 ]
 
 [[package]]
@@ -1336,28 +1371,15 @@ wheels = [
 ]
 
 [[package]]
-name = "ty"
-version = "0.0.35"
+name = "types-requests"
+version = "2.33.0.20260712"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/53/440e7b1212c4b0abbd4adb7aed93f4971aa1f8dca386ac5515930afa9172/ty-0.0.35.tar.gz", hash = "sha256:8375c240ab38138a19db07996c9808fb7a92047c1492e1ce587c2ef5112ad3a9", size = 5629237, upload-time = "2026-05-10T18:25:17.105Z" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084, upload-time = "2026-07-12T05:14:20.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/84/19662ee881675815b7fafff940a365be1985730465afd9b75cb2edd5f8b3/ty-0.0.35-py3-none-linux_armv6l.whl", hash = "sha256:85ae1e59b9fb0b40e9d84fe61b29653c5f2f5e78b487ece371a7a38c20c781cf", size = 11198741, upload-time = "2026-05-10T18:24:49.378Z" },
-    { url = "https://files.pythonhosted.org/packages/62/df/7e5b6f83d85b4d2e5b72b5dceb388f440acc10679417bd46f829b9200fab/ty-0.0.35-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:709dbb7af4fcadb1196863c00b8791bbbbcc9dacbe15a0ff17f0af82b35d415b", size = 10948304, upload-time = "2026-05-10T18:24:58.246Z" },
-    { url = "https://files.pythonhosted.org/packages/59/94/72d7263aca055cde427f0ebcf08d6a74e5a5fee1d1e7fdd553696089cecb/ty-0.0.35-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2cb0877419ab0c8708b6925cb0c2800b263842bd3c425113f200538772f3a0cc", size = 10407413, upload-time = "2026-05-10T18:24:37.422Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/23/fda6fae8a81ce0cb5f24cdfe63260e110c7af8844e31fa07d1e6e8ef0232/ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7afbcfc61904b7e82e7fe1a1db832a40d8f01e69dee1775f6594e552980536c", size = 10932614, upload-time = "2026-05-10T18:24:47.401Z" },
-    { url = "https://files.pythonhosted.org/packages/72/3d/b98d8d4aa1a5ed6daaf15864e838f605ca7b1e8b93b7e17b96ed4bc4dfed/ty-0.0.35-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b61498cc3e4178031c079951257fbdb209a891b4feb10ad6c40f615a51846f41", size = 10962982, upload-time = "2026-05-10T18:24:44.88Z" },
-    { url = "https://files.pythonhosted.org/packages/18/c4/2881aad71bf6fb2f8df17fc8e4bc89e904e54490a3ee747b5ef73f98ac85/ty-0.0.35-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:573b1eacda349fc8dba0d767b41631c3a6f66412363127c5bf2b1b40a1d898d2", size = 11476274, upload-time = "2026-05-10T18:24:42.4Z" },
-    { url = "https://files.pythonhosted.org/packages/34/0f/7717650adaeaddd23eea70470e2c26d3f0b9b18fdc7f26ec9552d6001f17/ty-0.0.35-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7209746158d6393c1040aa64b3ca29622e212ea7d8bae22ba50dbcbb4f96f0a", size = 12012027, upload-time = "2026-05-10T18:25:00.752Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c9/1a16cb4aab6f4707d8f550772e91abc26d1c8870f19b5e2453ad10bb8209/ty-0.0.35-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4466a1470aa4418d49a9aa45d9da7de42033addd0a2837c5b2b0eb71d3c2bcd3", size = 11648894, upload-time = "2026-05-10T18:25:12.44Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a1/a977c0e07e9f88db9c67f90c6342a4dc4422c8091fa07bf26521870687c5/ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb44bb742d52c309dcaa6598bcf4d82eb4bf1241b9e4940461e522e30093fe8b", size = 11560482, upload-time = "2026-05-10T18:25:05.172Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c1/a5fb11227d5cc4ac3f29a115d8c8bc817578e8ef6907d1e4c914ddbf45ee/ty-0.0.35-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:34b219250736c989b2670a03782c61315f523f3a2be37f1f90b1207e2212c188", size = 11718495, upload-time = "2026-05-10T18:24:54.12Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/cb/e92e4317388b6d1fd821a46941b448a8a1ff0bf13e22147c5167d8fa1b00/ty-0.0.35-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:88e2ac497decc0940ef1a07571dee8a746112a93a09cdc7f8bca0099752e2e05", size = 10900815, upload-time = "2026-05-10T18:25:02.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/4f/03bd87388a92567f262f35ac64e10d2be047d258f2dfcf1405f500fa2b90/ty-0.0.35-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:02cae51b53e6ec17d5d827ff1a3a76fd119705b56a92156e04399eda6e911596", size = 10998051, upload-time = "2026-05-10T18:25:14.68Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/60/6edbc375ee6073973200096168f644e1081e5e55a7d42596826465b275de/ty-0.0.35-py3-none-musllinux_1_2_i686.whl", hash = "sha256:11871d730c9400d899ac0b9f3d660ed2e7e433377c8725549f8250a36a7f2620", size = 11148910, upload-time = "2026-05-10T18:24:51.842Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/b1/a845d2066ed521c477450f436d4bd353d107e7c02dd6536a485944aaf892/ty-0.0.35-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1ad0a2f0530d0933dcc99ad36ac556c63e384ea72ab9a18d23ad2e2c9fd61c73", size = 11671005, upload-time = "2026-05-10T18:24:56.223Z" },
-    { url = "https://files.pythonhosted.org/packages/73/81/1d5912a54fb66b2f95ac828ae61d422ef5afeae1263e4d231e40796c229f/ty-0.0.35-py3-none-win32.whl", hash = "sha256:0e25d63ec4ab116e7f6757e44d16ca9216bca679d19ecc36d119cf80faada61a", size = 10481096, upload-time = "2026-05-10T18:24:39.976Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/36/1c7f8632bfec1c321f01581d4c940a3617b24bd3e8b37c8a7363d33fbfc4/ty-0.0.35-py3-none-win_amd64.whl", hash = "sha256:6a0a6d259f6f2f8f2f954c6f013d4e0b5eba68af6b353bf19a47d59ec254a3d5", size = 11555691, upload-time = "2026-05-10T18:25:07.792Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/fb/59325221bce52f6e833d6865ce8360ef7d5e1e21151b38df6dc77c4327a7/ty-0.0.35-py3-none-win_arm64.whl", hash = "sha256:619c52c0fb2aa21961a848a1995135ad3b6d0a9aa54da0194e60f679cc200e13", size = 10925457, upload-time = "2026-05-10T18:25:10.352Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392, upload-time = "2026-07-12T05:14:19.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary
- Replaced Ty with Pyrefly and configured Python 3.14 checking across application code, tests, benchmarks, and examples
- Added Pyrefly as a required CI gate and installed maintained pandas and requests stub packages
- Corrected type-safety gaps in Redis test data, Pub/Sub message handling, and benchmark result validation
- Replaced obsolete broad ignores with error-specific Pyrefly suppressions for confirmed redis-py and test-double typing limitations

## Rationale
- The project configuration mirrors the repository’s `src` layout while covering every maintained Python surface
- redis-py exposes several asynchronous commands as sync-or-async return unions – suppressing only `not-async` at the affected calls preserves checking everywhere else
- The Redis fixture deliberately injects a structural test double into an API annotated with the concrete client type – the single `bad-argument-type` suppression documents that boundary without weakening production types